### PR TITLE
Handle calls to repr() that produce exceptions

### DIFF
--- a/pympler/asizeof.py
+++ b/pympler/asizeof.py
@@ -532,7 +532,7 @@ def _repr(obj, clip=80):
     '''
     try:  # safe repr()
         r = repr(obj)
-    except TypeError:
+    except Exception:
         r = 'N/A'
     if 0 < clip < len(r):
         h = (clip // 2) - 2


### PR DESCRIPTION
Enhance "safe repr" in asizeof.py to handle calls to `repr` that produce other kinds of exceptions.

Of course, objects shouldn't produce such errors, but I ran into some while profiling my application. "N/A" is preferable to having pympler crash.

cc: @Pankrat
