### PR TITLE
Build matrix improvements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "pypy"
+  - "pypy3"
 before_install:
   - sudo apt-get install graphviz python-tk
 install:
-  - pip install Sphinx --use-mirrors
-  - pip install pep8 --use-mirrors
+  - travis_retry pip install Sphinx
+  - travis_retry pip install pep8
 script:
   - python setup.py try
   - python setup.py install


### PR DESCRIPTION
Added PyPy and PyPy3 to the build matrix and removed --use-mirrors since it's deprecated. Instead I used travis_retry in order to avoid build failures due to networking problems.
