### PR TITLE
Don't assume process name will have only one ':' character

### DIFF
--- a/pympler/process.py
+++ b/pympler/process.py
@@ -144,7 +144,7 @@ class _ProcessMemoryInfoProc(_ProcessMemoryInfo):
             self.pagefaults = int(stats[11])
 
             for entry in status.readlines():
-                key, value = entry.split(':')
+                key, value = entry.split(':', 1)
                 size_in_bytes = lambda x: int(x.split()[0]) * 1024
                 if key == 'VmData':
                     self.data_segment = size_in_bytes(value)


### PR DESCRIPTION
Hi,

it is possible for names of processes to contain the colon character ':' - without the patch the split on ':' will fail because it assumes ':' won't appear in their names.

Cheers.