### PR TITLE
Fix compatibility with Python 2.6

### DIFF
--- a/pympler/summary.py
+++ b/pympler/summary.py
@@ -144,8 +144,8 @@ def get_diff(left, right):
     """
     res = []
 
-    right_by_key = {r[0]:r for r in right}
-    left_by_key  = {r[0]:r for r in left}
+    right_by_key = dict((r[0], r) for r in right)
+    left_by_key  = dict((r[0], r) for r in left)
 
     keys = set(right_by_key)
     keys.update(left_by_key)


### PR DESCRIPTION
Python 2.6 doesn't have dict comprehensions; use `dict(<generator expression>)` instead.

Fixes:
```
Traceback (most recent call last):
  File "test/runtest.py", line 136, in <module>
    tst, all = suite(dirs, clean=clean, pre=pre, verbose=verbose)
  File "test/runtest.py", line 70, in suite
    mod = __import__(test, globals(), locals(), [mod])
  File ".../test/muppy/test_muppy.py", line 7, in <module>
    import pympler.muppy
  File ".../pympler/muppy.py", line 3, in <module>
    from pympler import summary
  File ".../pympler/summary.py", line 147
    right_by_key = {r[0]:r for r in right}
                             ^
SyntaxError: invalid syntax
```
introduced in 5da73b5b19581a7ab9ca8810fd16ba5e6835c536.