### PR TITLE
Update asizeof

### DIFF
--- a/pympler/asizeof.py
+++ b/pympler/asizeof.py
@@ -1,210 +1,270 @@
 #!/usr/bin/env python
 
-# Copyright, license and disclaimer are at the end of this file.
+# Copyright, license and disclaimer are at the very end of this file.
 
 # This is the latest, enhanced version of the asizeof.py recipes at
-# <http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/546530>
-# <http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/544288>
+# <http://github.com/ActiveState/code/blob/master/recipes/Python/
+#         546530_Size_of_Python_objects_revised/recipe-546530.py>,
+# <http://code.activestate.com/recipes/546530-size-of-python-objects-revised>
+# and <http://code.activestate.com/recipes/544288-size-of-python-objects>.
+
+# Recent versions of this module handle objects like ``namedtuples``,
+# ``closure``, and NumPy data ``arange``, ``array``, ``matrix``, etc.
+
+# See also project Pympler at <https://github.com/pympler/pympler> and
+# memory footprint recipe <http://code.activestate.com/recipes/577504/>.
+
+# Tested with 64-bit Python 2.6.9 (and numpy 1.6.2), 2.7.13 (and numpy
+# 1.13.1), 3.5.3 and 3.6.2 on macOS 10.12.6 Sierra, with 64-bit Intel-
+# Python 3.5.3 (and numpy 1.11.3) on macOS 10.12.6 Sierra and with
+# Pythonista 3.1 using 64-bit Python 2.7.12 and 3.5.1 (both with numpy
+# 1.8.0) on iOS 10.3.3.
+
+# Earlier versions of this module were tested with 32-bit Python 2.2.3,
+# 2.3.7, 2.4.5, 2.5.1, 2.5.2, 2.6.2, 3.0.1 or 3.1a2 on CentOS 4.6, SuSE
+# 9.3, MacOS X 10.3.9 Panther (PPC), MacOS X 10.4.11 Tiger, Solaris 10
+# (Opteron) and Windows XP, with 64-bit Python 3.0.1 on RHEL 3u7 and
+# Solaris 10 (Opteron) and with 64-bit Python 2.7.10 and 3.5.1 on MacOS
+# X 10.11.5 El Capitan (all without numpy).
+
+# This module was checked statically with PyChecker 0.8.12, PyFlakes
+# 1.5.0, PyCodeStyle 2.3.1 (formerly Pep8) and McCabe 0.6.1 using Python
+# 2.7.13 and with Flake8 3.3.0 using Python 3.6.2, all thru this post-
+# processor <http://code.activestate.com/recipes/546532/>
 
 '''
-This module exposes 9 functions and 2 classes to obtain lengths and
-sizes of Python objects (for Python 2.6 or later).
-
-Earlier versions of this module supported Python versions down to
-Python 2.2. If you are running Python < 2.5 please consider
-downgrading Pympler to version 0.3.x.
+This module exposes 9 functions and 2 classes to obtain lengths (in
+items) and sizes (in bytes) of Python objects for Python 2.6 and later,
+including Python 3+ [#v]_.
 
 **Public Functions** [#unsafe]_
 
-   Function **asizeof** calculates the combined (approximate) size
-   of one or several Python objects in bytes.  Function **asizesof**
-   returns a tuple containing the (approximate) size in bytes for
-   each given Python object separately.  Function **asized** returns
-   for each object an instance of class **Asized** containing all the
-   size information of the object and a tuple with the referents.
+    Function **asizeof** calculates the combined (approximate) size
+    in bytes of one or several Python objects.
 
-   Functions **basicsize** and **itemsize** return the basic resp. item
-   size of the given object.
+    Function **asizesof** returns a tuple containing the (approximate)
+    size in bytes for each given Python object separately.
 
-   Function **flatsize** returns the flat size of a Python object in
-   bytes defined as the basic size plus the item size times the
-   length of the given object.
+    Function **asized** returns for each object an instance of class
+    **Asized** containing all the size information of the object and
+    a tuple with the referents [#refs]_.
 
-   Function **leng** returns the length of an object, like standard
-   ``len`` but extended for several types, e.g. the **leng** of a
-   multi-precision int (or long) is the number of ``digits`` [#digit]_.
-   The length of most mutable sequence objects includes an estimate of
-   the over-allocation and therefore, the **leng** value may differ
-   from the standard ``len`` result.
+    Functions **basicsize** and **itemsize** return the *basic*
+    respectively *itesize* of the given object, both in bytes.  For
+    objects as ``array.array``, ``numpy.array``, ``numpy.matrix``,
+    etc. where the item size varies depending on the instance-specific
+    data type, function **itemsize** returns that item size.
 
-   Function **refs** returns (a generator for) the referents of the
-   given object, i.e. the objects referenced by the given object.
+    Function **flatsize** returns the *flat size* of a Python object
+    in bytes defined as the *basic size* plus the *item size* times
+    the *length* of the given object.
 
-   Certain classes are known to be sub-classes of or to behave as
-   dict objects.  Function **adict** can be used to install other
-   class objects to be treated like dict.
+    Function **alen** [#alen]_ returns the *length* of an object like
+    standard function ``len`` but extended for several types.  E.g.
+    the **alen** of a multi-precision int (or long) is the number of
+    ``digits`` [#digit]_.  The *length* of most *mutable* sequence
+    objects includes an estimate of the over-allocation and therefore,
+    the **alen** value may differ from the standard ``len`` result.
+    For objects like ``array.array``, ``numpy.array``, ``numpy.matrix``,
+    etc. function **alen** returns the proper number of items.
+
+    Function **refs** returns (a generator for) the referents [#refs]_
+    of the given object.
+
+    Certain classes are known to be sub-classes of or to behave as
+    ``dict`` objects.  Function **adict** can be used to install
+    other class objects to be treated like ``dict``.
 
 **Public Classes** [#unsafe]_
 
-   An instance of class **Asized** is returned for each object sized
-   with the **asized** function or method.
+    Class **Asizer** may be used to accumulate the results of several
+    sizing calls.  After creating an **Asizer** instance, use methods
+    **asizeof** and **asizesof** as needed to size any number of
+    additional objects and accumulate the sizes.
 
-   Class **Asizer** may be used to accumulate the results of several
-   **asizeof** or **asizesof** calls.  After creating an **Asizer** instance,
-   use methods **asizeof** and **asizesof** as needed to size any
-   number of additional objects.
+    Call methods **exclude_refs** and/or **exclude_types** to exclude
+    references to respectively instances or types of certain objects.
 
-   Call methods **exclude_refs** and/or **exclude_types** to exclude
-   references to resp. instances or types of certain objects.
-   Use one of the **print\_... methods** to report the statistics.
+    Use one of the **print\_...** methods to report the statistics.
+
+    An instance of class **Asized** is returned for each object sized
+    with the **asized** function or method.
 
 **Duplicate Objects**
 
-   Any duplicate, given objects are sized only once and the size
-   is included in the combined total only once.  But functions
-   **asizesof** and **asized** do return a size value resp. an
-   **Asized** instance for each given object, including duplicates.
+    Any duplicate, given objects are sized only once and the size
+    is included in the combined total only once.  But functions
+    **asizesof** and **asized** will return a size value respectively
+    an **Asized** instance for each given object, including duplicates.
 
 **Definitions** [#arb]_
 
-   The size of an object is defined as the sum of the flat size
-   of the object plus the sizes of any referents.  Referents are
-   visited recursively up to a given limit.  However, the size
-   of objects referenced multiple times is included only once.
+    The *length* of an objects like ``dict``, ``list``, ``set``,
+    ``str``, ``tuple``, etc. is defined as the number of items held
+    in or allocated by the object.  Held items are *references* to
+    other objects, called the *referents*.
 
-   The flat size of an object is defined as the basic size of the
-   object plus the item size times the number of allocated items.
-   The flat size does include the size for the items (references
-   to the referents), but not the referents themselves.
+    The *size* of an object is defined as the sum of the *flat size*
+    of the object plus the sizes of any referents [#refs]_.  Referents
+    are visited recursively up to the specified detail level.  However,
+    the size of objects referenced multiple times is included only once
+    in the total *size*.
 
-   The flat size returned by function **flatsize** equals the result
-   of the **asizeof** function with options *code=True*, *ignored=False*,
-   *limit=0* and option *align* set to the same value.
+    The *flat size* of an object is defined as the *basic size* of the
+    object plus the *item size* times the number of allocated *items*,
+    *references* to referents.  The *flat size* does include the size
+    for the *references* to the referents, but not the size of the
+    referents themselves.
 
-   The accurate flat size for an object is obtained from function
-   ``sys.getsizeof()`` where available.  Otherwise, the length and
-   size of sequence objects as dicts, lists, sets, etc. is based
-   on an estimate for the number of allocated items.  As a result,
-   the reported length and size may substantially differ from the
-   actual length and size.
+    The *flat size* returned by function *flatsize* equals the result
+    of function *asizeof* with options *code=True*, *ignored=False*,
+    *limit=0* and option *align* set to the same value.
 
-   The basic and item sizes are obtained from the ``__basicsize__``
-   resp. ``__itemsize__`` attributes of the (type of the) object.
-   Where necessary (e.g. sequence objects), a zero ``__itemsize__``
-   is replaced by the size of a corresponding C type.  The basic
-   size (of GC managed objects) objects includes the overhead for
-   Python's garbage collector (GC) as well as the space needed for
-   ``refcounts`` (used only in certain Python builds).
+    The accurate *flat size* for an object is obtained from function
+    ``sys.getsizeof()`` where available.  Otherwise, the *length* and
+    *size* of sequence objects as ``dicts``, ``lists``, ``sets``, etc.
+    is based on an estimate for the number of allocated items.  As a
+    result, the reported *length* and *size* may differ substantially
+    from the actual *length* and *size*.
 
-   Optionally, size values can be aligned to any power of 2 multiple.
+    The *basic* and *item size* are obtained from the ``__basicsize__``
+    respectively ``__itemsize__`` attributes of the (type of the)
+    object.  Where necessary (e.g. sequence objects), a zero
+    ``__itemsize__`` is replaced by the size of a corresponding C type.
+
+    The overhead for Python's garbage collector (GC) is included in
+    the *basic size* of (GC managed) objects as well as the space
+    needed for ``refcounts`` (used only in certain Python builds).
+
+    Optionally, size values can be aligned to any power of 2 multiple.
 
 **Size of (byte)code**
 
-   The (byte)code size of objects like classes, functions, methods,
-   modules, etc. can be included by setting option *code=True*.
+    The *(byte)code size* of objects like classes, functions, methods,
+    modules, etc. can be included by setting option *code=True*.
 
-   Iterators are handled similar to sequences: iterated object(s)
-   are sized like referents, only if the recursion *limit* permits.
-   Also, function ``gc.get_referents()`` must return the referent
-   object of iterators.
+    Iterators are handled like sequences: iterated object(s) are
+    sized like *referents* [#refs]_ but only up to the specified level
+    or recursion *limit* (and only if function ``gc.get_referents()``
+    returns the referent object of iterators).
 
-   Generators are sized as (byte)code only, but the generated
-   objects are never sized.
+    Generators are sized as *(byte)code* only, but the generated objects
+    are never sized.
 
 **Old- and New-style Classes**
 
-   All old- and new-style class, instance and type objects, are
-   handled uniformly such that (a) instance objects are distinguished
-   from class objects and (b) instances of different old-style classes
-   can be dealt with separately.
+    All old- and new-style ``class``, instance and ``type`` objects,
+    are handled uniformly such that (a) instance objects are distinguished
+    from class objects and (b) instances of different old-style classes
+    can be dealt with separately.
 
-   Class and type objects are represented as <class ....* def>
-   resp. <type ... def> where an '*' indicates an old-style class
-   and the  def suffix marks the definition object.  Instances of
-   old-style classes are shown as new-style ones but with an '*'
-   at the end of the name, like <class module.name*>.
+    Class and type objects are represented as ``<class ....* def>``
+    respectively ``<type ... def>`` where the ``*`` indicates an old-style
+    class and the ``... def`` suffix marks the *definition object*.
+    Instances of  classes are shown as ``<class module.name*>`` without
+    the ``... def`` suffix.  The ``*`` after the name indicates an
+    instance of an old-style class.
 
 **Ignored Objects**
 
-   To avoid excessive sizes, several object types are ignored [#arb]_ by
-   default, e.g. built-in functions, built-in types and classes [#bi]_,
-   function globals and module referents.  However, any instances
-   thereof are sized and module objects will be sized when passed
-   as given objects.  Ignored object types are included if option
-   *ignored* is set accordingly.
+    To avoid excessive sizes, several object types are ignored [#arb]_
+    by default, e.g. built-in functions, built-in types and classes
+    [#bi]_, function globals and module referents.  However, any
+    instances thereof and module objects will be sized when passed as
+    given objects.  Ignored object types are included unless option
+    *ignored* is set accordingly.
 
-   In addition, many ``__...__`` attributes of callable objects are
-   ignored [#arb]_, except crucial ones, e.g. class attributes ``__dict__``,
-   ``__doc__``, ``__name__`` and ``__slots__``.  For more details, see the
-   type-specific ``_..._refs()`` and ``_len_...()`` functions below.
+    In addition, many ``__...__`` attributes of callable objects are
+    ignored [#arb]_, except crucial ones, e.g. class attributes ``__dict__``,
+    ``__doc__``, ``__name__`` and ``__slots__``.  For more details, see
+    the type-specific ``_..._refs()`` and ``_len_...()`` functions below.
 
 .. rubric:: Footnotes
 .. [#unsafe] The functions and classes in this module are not thread-safe.
 
-.. [#digit] See Python source file ``.../Include/longinterp.h`` for the
-     C ``typedef`` of ``digit`` used in multi-precision int (or
-     long) objects.  The C ``sizeof(digit)`` in bytes can be obtained
-     in Python from the int (or long) ``__itemsize__`` attribute.
-     Function **leng** determines the number of ``digits`` of an
-     int (or long) value.
+.. [#v] Earlier editions of this module supported Python versions down
+    to Python 2.2.  To use Python 2.5 or older, try module ``asizeof``
+    from project `Pympler 0.3.x <https://github.com/pympler/pympler>`_.
+
+.. [#alen] Former function *leng*, class attribute *leng* and keyword
+    argument *leng* have all been renamed to *alen*.  However, function
+    *leng* is still available for backward compatibility.
+
+.. [#refs] The *referents* of an object are the objects referenced *by*
+    that object.  For example, the *referents* of a ``list`` are the
+    objects held in the ``list``, the *referents* of a ``dict`` are
+    the key and value objects in the ``dict``, etc.
 
 .. [#arb] These definitions and other assumptions are rather arbitrary
-     and may need corrections or adjustments.
+    and may need corrections or adjustments.
 
-.. [#bi] Types and classes are considered built-in if the ``__module__``
-     of the type or class is listed in ``_builtin_modules`` below.
+.. [#digit] See Python source file ``.../Include/longinterp.h`` for the
+    C ``typedef`` of ``digit`` used in multi-precision int (or long)
+    objects.  The C ``sizeof(digit)`` in bytes can be obtained in
+    Python from the int (or long) ``__itemsize__`` attribute.
+    Function **alen** determines the number of ``digits`` of an int
+    (or long) object.
+
+.. [#bi] ``Type``s and ``class``es are considered built-in if the
+    ``__module__`` of the type or class is listed in the private
+    ``_builtin_modules``.
 '''
+import sys
+if sys.version_info < (2, 6, 0):
+    raise NotImplementedError('%s requires Python 2.6 or newer' % ('asizeof',))
 
-from inspect import (isbuiltin, isclass, iscode, isframe, isfunction, ismethod,
-                     ismodule, stack)
+from inspect import (isbuiltin, isclass, iscode, isframe, isfunction,
+                     ismethod, ismodule, stack)
 from math import log
 from os import curdir, linesep
 from struct import calcsize  # type/class Struct only in Python 2.5+
-import sys
 import types as Types
 import warnings
 import weakref as Weakref
 
 __all__ = ['adict', 'asized', 'asizeof', 'asizesof',
            'Asized', 'Asizer',  # classes
-           'basicsize', 'flatsize', 'itemsize', 'leng', 'refs']
+           'basicsize', 'flatsize', 'itemsize', 'alen', 'refs']
+__version__ = '17.10.16'
 
- # any classes or types in modules listed in _builtin_modules are
- # considered built-in and ignored by default, as built-in functions
+# any classes or types in modules listed in _builtin_modules are
+# considered built-in and ignored by default, as built-in functions
 if __name__ == '__main__':
     _builtin_modules = (int.__module__, 'types', Exception.__module__)  # , 'weakref'
 else:  # treat this very module as built-in
     _builtin_modules = (int.__module__, 'types', Exception.__module__, __name__)  # , 'weakref'
 
- # sizes of some primitive C types
- # XXX len(pack(T, 0)) == Struct(T).size == calcsize(T)
+# sizes of some primitive C types
+# XXX len(pack(T, 0)) == Struct(T).size == calcsize(T)
 _sizeof_Cbyte = calcsize('c')  # sizeof(unsigned char)
 _sizeof_Clong = calcsize('l')  # sizeof(long)
 _sizeof_Cvoidp = calcsize('P')  # sizeof(void*)
 
+# sizeof(long) != sizeof(ssize_t) on LLP64
+if _sizeof_Clong < _sizeof_Cvoidp:  # pragma: no coverage
+    _z_P_L = 'P'
+else:
+    _z_P_L = 'L'
+
 
 def _calcsize(fmt):
-    '''struct.calcsize() handling 'z' for Py_ssize_t.
+    '''Like struct.calcsize() but handling 'z' for Py_ssize_t.
     '''
-     # sizeof(long) != sizeof(ssize_t) on LLP64
-    if _sizeof_Clong < _sizeof_Cvoidp:  # pragma: no coverage
-        z = 'P'
-    else:
-        z = 'L'
-    return calcsize(fmt.replace('z', z))
+    return calcsize(fmt.replace('z', _z_P_L))
 
- # defaults for some basic sizes with 'z' for C Py_ssize_t
+
+# defaults for some basic sizes with 'z' for C Py_ssize_t
 _sizeof_CPyCodeObject = _calcsize('Pz10P5i0P')  # sizeof(PyCodeObject)
 _sizeof_CPyFrameObject = _calcsize('Pzz13P63i0P')  # sizeof(PyFrameObject)
 _sizeof_CPyModuleObject = _calcsize('PzP0P')  # sizeof(PyModuleObject)
 
- # defaults for some item sizes with 'z' for C Py_ssize_t
+# defaults for some item sizes with 'z' for C Py_ssize_t
 _sizeof_CPyDictEntry = _calcsize('z2P')  # sizeof(PyDictEntry)
 _sizeof_Csetentry = _calcsize('lP')  # sizeof(setentry)
 
 try:  # C typedef digit for multi-precision int (or long)
     _sizeof_Cdigit = long.__itemsize__
-except NameError:  # no long in Python 3.0
+except NameError:  # no long in Python 3+
     _sizeof_Cdigit = int.__itemsize__
 if _sizeof_Cdigit < 2:  # pragma: no coverage
     raise AssertionError('sizeof(%s) bad: %d' % ('digit', _sizeof_Cdigit))
@@ -212,7 +272,7 @@ if _sizeof_Cdigit < 2:  # pragma: no coverage
 # Get character size for internal unicode representation in Python < 3.3
 try:  # sizeof(unicode_char)
     u = unicode('\0')
-except NameError:  # no unicode() in Python 3.0
+except NameError:  # no unicode() in Python 3+
     u = '\0'
 u = u.encode('unicode-internal')  # see .../Lib/test/test_sys.py
 _sizeof_Cunicode = len(u)
@@ -222,13 +282,13 @@ try:  # size of GC header, sizeof(PyGC_Head)
     import _testcapi as t
     _sizeof_CPyGC_Head = t.SIZEOF_PYGC_HEAD  # new in Python 2.6
 except (ImportError, AttributeError):  # sizeof(PyGC_Head)
-     # alignment should be to sizeof(long double) but there
-     # is no way to obtain that value, assume twice double
+    # alignment should be to sizeof(long double) but there
+    # is no way to obtain that value, assume twice double
     t = calcsize('2d') - 1
     _sizeof_CPyGC_Head = (_calcsize('2Pz') + t) & ~t
 del t
 
- # size of refcounts (Python debug build only)
+# size of refcounts (Python debug build only)
 if hasattr(sys, 'gettotalrefcount'):  # pragma: no coverage
     _sizeof_Crefcounts = _calcsize('2z')
 else:
@@ -240,15 +300,15 @@ except ImportError:
     class ABCMeta(type):
         pass
 
- # some flags from .../Include/object.h
+# some flags from .../Include/object.h
 _Py_TPFLAGS_HEAPTYPE = 1 << 9  # Py_TPFLAGS_HEAPTYPE
 _Py_TPFLAGS_HAVE_GC = 1 << 14  # Py_TPFLAGS_HAVE_GC
 
 _Type_type = type(type)  # == type and new-style class type
 
 
- # compatibility functions for more uniform
- # behavior across Python version 2.2 thu 3.0
+# compatibility functions for more uniform
+# behavior across Python version 2.2 thu 3.0
 
 def _items(obj):  # dict only
     '''Return iter-/generator, preferably.
@@ -263,56 +323,63 @@ def _keys(obj):  # dict only
 
 
 def _values(obj):  # dict only
-    '''Use iter-/generator, preferably.
+    '''Return iter-/generator, preferably.
     '''
     return getattr(obj, 'itervalues', obj.values)()
 
+
 try:  # callable() builtin
-    _callable = callable
-except NameError:  # callable() removed in Python 3.0
-    def _callable(obj):
+    _iscallable = callable
+except NameError:  # callable() removed in Python 3+
+    def _iscallable(obj):
         '''Substitute for callable().'''
         return hasattr(obj, '__call__')
 
-try:  # only used to get the referents of
-      # iterators, but gc.get_referents()
-      # returns () for dict...-iterators
+# 'cell' is holding data used in closures
+c = (lambda unused: (lambda: unused))(None)
+try:
+    _cell_type = type(c.__closure__[0])
+except AttributeError:  # Python 2.5
+    _cell_type = type(c.func_closure[0])
+del c
+
+try:
+    from gc import get_objects as _getobjects  # containers only?
+except ImportError:
+    def _getobjects():
+        # modules first, globals and stack
+        # objects (may contain duplicates)
+        return tuple(_values(sys.modules)) + (
+               globals(), stack(sys.getrecursionlimit())[2:])
+
+try:  # only used to get referents of
+    # iterators, but gc.get_referents()
+    # returns () for dict...-iterators
     from gc import get_referents as _getreferents
 except ImportError:
     def _getreferents(unused):
         return ()  # sorry, no refs
 
-_getsizeof = sys.getsizeof
-
-version = sys.version_info
-_getsizeof_bugs = (version[0] == 2 and version < (2, 7, 4) or
-                   version[0] == 3 and version < (3, 2, 4))
-
-
-def _getsizeof_exclude(getsizeof, exclude):
-    def _getsizeof_wrapper(obj, default):
-        if isinstance(obj, exclude):
-            return default
-        else:
-            return getsizeof(obj, default)
-    return _getsizeof_wrapper
-
+# sys.getsizeof() new in Python 2.6, adjusted below
+_getsizeof = getattr(sys, 'getsizeof', None)
 
 try:  # str intern()
     _intern = intern
-except NameError:  # no intern() in Python 3.0
+except NameError:  # no intern() in Python 3+
     def _intern(val):
         return val
 
+_isiOS = sys.platform == 'ios'  # Apple iOS
 
- # private functions
+
+# private functions
 
 def _basicsize(t, base=0, heap=False, obj=None):
     '''Get non-zero basicsize of type,
        including the header sizes.
     '''
     s = max(getattr(t, '__basicsize__', 0), base)
-     # include gc header size
+    # include gc header size
     if t != _Type_type:
         h = getattr(t, '__flags__', 0) & _Py_TPFLAGS_HAVE_GC
     elif heap:  # type, allocated on heap
@@ -321,8 +388,20 @@ def _basicsize(t, base=0, heap=False, obj=None):
         h = getattr(obj, '__flags__', 0) & _Py_TPFLAGS_HEAPTYPE
     if h:
         s += _sizeof_CPyGC_Head
-     # include reference counters
+    # include reference counters
     return s + _sizeof_Crefcounts
+
+
+def _c100(stats):
+    '''Cutoff as percentage.
+    '''
+    return int((stats - int(stats)) * 100.0 + 0.5)
+
+
+def _classof(obj, dflt=None):
+    '''Return the object's class object.
+    '''
+    return getattr(obj, '__class__', dflt)
 
 
 def _derive_typedef(typ):
@@ -343,9 +422,9 @@ def _dir2(obj, pref='', excl=(), slots=None, itor=''):
     '''
     if slots:  # __slots__ attrs
         if hasattr(obj, slots):
-             # collect all inherited __slots__ attrs
-             # from list, tuple, or dict __slots__,
-             # while removing any duplicate attrs
+            # collect all inherited __slots__ attrs
+            # from list, tuple, or dict __slots__,
+            # while removing any duplicate attrs
             s = {}
             for c in type(obj).mro():
                 for a in getattr(c, slots, ()):
@@ -353,8 +432,8 @@ def _dir2(obj, pref='', excl=(), slots=None, itor=''):
                         a = '_' + c.__name__ + a
                     if hasattr(obj, a):
                         s.setdefault(a, getattr(obj, a))
-             # assume __slots__ tuple/list
-             # is holding the attr values
+            # assume __slots__ tuple/list
+            # is holding the attr values
             yield slots, _Slots(s)  # _keys(s)
             for t in _items(s):
                 yield t  # attr name, value
@@ -363,25 +442,68 @@ def _dir2(obj, pref='', excl=(), slots=None, itor=''):
             yield itor, o
     else:  # regular attrs
         for a in dir(obj):
-            if a.startswith(pref) and a not in excl and hasattr(obj, a):
+            if a.startswith(pref) and hasattr(obj, a) and a not in excl:
                 yield a, getattr(obj, a)
 
 
 def _infer_dict(obj):
-    '''Return True for likely dict object.
+    '''Return True for likely dict object via duck typing.
     '''
-    for ats in (('__len__', 'get', 'has_key', 'items', 'keys', 'values'),
+    for ats in (('__len__', 'get', 'has_key', 'items', 'keys', 'update', 'values'),
                 ('__len__', 'get', 'has_key', 'iteritems', 'iterkeys', 'itervalues')):
-        if all(_callable(getattr(obj, a, None)) for a in ats):
+        if all(_iscallable(getattr(obj, a, None)) for a in ats):
             return True
     return False
+
+
+def _iscell(obj):
+    '''Return True if obj is a cell as used in a closure.
+    '''
+    return isinstance(obj, _cell_type)
 
 
 def _isdictclass(obj):
     '''Return True for known dict objects.
     '''
-    c = getattr(obj, '__class__', None)
+    c = _classof(obj)
     return c and c.__name__ in _dict_classes.get(c.__module__, ())
+
+
+def _isframe(obj):
+    '''Return True for a stack frame object.
+    '''
+    try:  # safe isframe(), see pympler.muppy
+        return isframe(obj)
+    except ReferenceError:
+        return False
+
+
+def _isnamedtuple(obj):
+    '''Named tuples are identified via duck typing:
+       <http://www.gossamer-threads.com/lists/python/dev/1142178>
+    '''
+    return isinstance(obj, tuple) and hasattr(obj, '_fields')
+
+
+def _isNULL(obj):
+    '''Prevent asizeof(all=True, ...) crash.
+
+       Sizing gc.get_objects() crashes in Pythonista3 with
+       Python 3.5.1 on iOS due to 1-tuple (<Null>,) object,
+       see <https://forum.omz-software.com/user/mrjean1>.
+    '''
+    return isinstance(obj, tuple) and len(obj) == 1 \
+                                  and repr(obj) == '(<NULL>,)'
+
+
+def _isnumpy(obj):
+    '''Return True for a NumPy arange, array, matrix, etc. instance.
+    '''
+    if _numpy_types:  # see also _len_numpy
+        return isinstance(obj, _numpy_types) or \
+             (_moduleof(_classof(obj)).startswith('numpy') and
+               hasattr(obj, 'nbytes'))
+    return False
 
 
 def _issubclass(sub, sup):
@@ -395,27 +517,10 @@ def _issubclass(sub, sup):
     return False
 
 
-# 'cell' is holding data used in closures
-closure = (lambda x: (lambda: x))(None)
-cell_type = type(closure.__closure__[0])
-
-
-def _iscell(obj):
-    '''Return True if obj is a cell as used in a closure.'''
-    return isinstance(obj, cell_type)
-
-
-def _isnamedtuple(obj):
-    '''Named tuples are identified via duck typing:
-    http://www.gossamer-threads.com/lists/python/dev/1142178
-    '''
-    return isinstance(obj, tuple) and hasattr(obj, '_fields')
-
-
 def _itemsize(t, item=0):
     '''Get non-zero itemsize of type.
     '''
-     # replace zero value with default
+    # replace zero value with default
     return getattr(t, '__itemsize__', 0) or item
 
 
@@ -428,14 +533,20 @@ def _kwdstr(**kwds):
 def _lengstr(obj):
     '''Object length as a string.
     '''
-    n = leng(obj)
+    n = alen(obj)
     if n is None:  # no len
         r = ''
     elif n > _len(obj):  # extended
-        r = ' leng %d!' % n
+        r = ' alen %d!' % n
     else:
-        r = ' leng %d' % n
+        r = ' alen %d' % n
     return r
+
+
+def _moduleof(obj, dflt=''):
+    '''Return the object's module name.
+    '''
+    return getattr(obj, '__module__', dflt)
 
 
 def _nameof(obj, dflt=''):
@@ -452,11 +563,10 @@ def _objs_opts(objs, all=None, **opts):
         t = objs
     elif all in (False, None):
         t = ()
-    elif all is True:  # 'all' objects ...
-         # ... modules first, globals and stack
-         # (may contain duplicate objects)
-        t = tuple(_values(sys.modules)) + (
-            globals(), stack(sys.getrecursionlimit())[2:])
+    elif all is True:  # 'all' objects
+        t = _getobjects()
+        if _isiOS:  # avoid iOS/Pythonista3/Python 3 crash
+            t = tuple(o for o in t if not _isNULL(o))
     else:
         raise ValueError('invalid option: %s=%r' % ('all', all))
     return t, opts
@@ -483,7 +593,7 @@ def _plural(num):
 
 
 def _power2(n):
-    '''Find the next power of 2.
+    '''Finds the next power of 2.
     '''
     p2 = 16
     while n > p2:
@@ -498,42 +608,44 @@ def _prepr(obj, clip=0):
 
 
 def _printf(fmt, *args, **print3opts):
-    '''Formatted print.
+    '''Formatted print to sys.stdout or given stream.
+
+        *print3opts* -- some keyword arguments, like Python 3+ print.
     '''
-    if print3opts:  # like Python 3.0
+    if print3opts:  # like Python 3+
         f = print3opts.get('file', None) or sys.stdout
         if args:
             f.write(fmt % args)
         else:
             f.write(fmt)
         f.write(print3opts.get('end', linesep))
+        if print3opts.get('flush', False):
+            f.flush()
     elif args:
         print(fmt % args)
     else:
         print(fmt)
 
 
-def _refs(obj, named, *ats, **kwds):
+def _refs(obj, named, *attrs, **kwds):
     '''Return specific attribute objects of an object.
     '''
     if named:
-        for a in ats:  # cf. inspect.getmembers()
-            if hasattr(obj, a):
-                yield _NamedRef(a, getattr(obj, a))
-        if kwds:  # kwds are _dir2() args
-            for a, o in _dir2(obj, **kwds):
-                yield _NamedRef(a, o)
+        _N = _NamedRef
     else:
-        for a in ats:  # cf. inspect.getmembers()
-            if hasattr(obj, a):
-                yield getattr(obj, a)
-        if kwds:  # kwds are _dir2() args
-            for _, o in _dir2(obj, **kwds):
-                yield o
+        def _N(_, o):
+            return o
+
+    for a in attrs:  # cf. inspect.getmembers()
+        if hasattr(obj, a):
+            yield _N(a, getattr(obj, a))
+    if kwds:  # kwds are _dir2() args
+        for a, o in _dir2(obj, **kwds):
+            yield _N(a, o)
 
 
 def _repr(obj, clip=80):
-    '''Clip long repr() string.
+    '''Clips long repr() string.
     '''
     try:  # safe repr()
         r = repr(obj)
@@ -564,7 +676,11 @@ def _SI2(size, **kwds):
     return str(size) + _SI(size, **kwds)
 
 
- # type-specific referent functions
+# type-specific referents functions
+
+def _cell_refs(obj, named):
+    return _refs(obj, named, 'cell_contents')
+
 
 def _class_refs(obj, named):
     '''Return specific referents of a class object.
@@ -582,18 +698,18 @@ def _co_refs(obj, named):
 def _dict_refs(obj, named):
     '''Return key and value objects of a dict/proxy.
     '''
-    if named:
-        for k, v in _items(obj):
-            s = str(k)
-            yield _NamedRef('[K] ' + s, k)
-            yield _NamedRef('[V] ' + s + ': ' + _repr(v), v)
-    else:
-        try:
+    try:
+        if named:
+            for k, v in _items(obj):
+                s = str(k)
+                yield _NamedRef('[K] ' + s, k)
+                yield _NamedRef('[V] ' + s + ': ' + _repr(v), v)
+        else:
             for k, v in _items(obj):
                 yield k
                 yield v
-        except ReferenceError:
-            warnings.warn("Reference error while iterating over '%s'" % str(obj.__class__))
+    except ReferenceError:
+        warnings.warn("Reference error iterating '%s'" % (_classof(obj),))
 
 
 def _enum_refs(obj, named):
@@ -605,7 +721,7 @@ def _enum_refs(obj, named):
 def _exc_refs(obj, named):
     '''Return specific referents of an Exception object.
     '''
-     # .message raises DeprecationWarning in Python 2.6
+    # .message raises DeprecationWarning in Python 2.6
     return _refs(obj, named, 'args', 'filename', 'lineno', 'msg', 'text')  # , 'message', 'mixed'
 
 
@@ -628,23 +744,10 @@ def _func_refs(obj, named):
                  pref='func_', excl=('func_globals',))
 
 
-def _cell_refs(obj, named):
-    return _refs(obj, named, 'cell_contents')
-
-
-def _namedtuple_refs(obj, named):
-    '''Return specific referents of obj-as-sequence and slots but exclude dict.
-    '''
-    for r in _refs(obj, named, '__class__', slots='__slots__'):
-        yield r
-    for r in obj:
-        yield r
-
-
 def _gen_refs(obj, named):
     '''Return the referent(s) of a generator object.
     '''
-     # only some gi_frame attrs
+    # only some gi_frame attrs
     f = getattr(obj, 'gi_frame', None)
     return _refs(f, named, 'f_locals', 'f_code')
 
@@ -671,11 +774,20 @@ def _iter_refs(obj, named):
 def _module_refs(obj, named):
     '''Return specific referents of a module object.
     '''
-     # ignore this very module
+    # ignore this very module
     if obj.__name__ == __name__:
         return ()
-     # module is essentially a dict
+    # module is essentially a dict
     return _dict_refs(obj.__dict__, named)
+
+
+def _namedtuple_refs(obj, named):
+    '''Return specific referents of obj-as-sequence and slots but exclude dict.
+    '''
+    for r in _refs(obj, named, '__class__', slots='__slots__'):
+        yield r
+    for r in obj:
+        yield r
 
 
 def _prop_refs(obj, named):
@@ -720,7 +832,7 @@ def _weak_refs(obj, unused):  # named unused for PyChecker
     '''
     try:  # ignore 'key' of KeyedRef
         return (obj(),)
-    except:  # XXX ReferenceError
+    except Exception:  # XXX ReferenceError
         return ()
 
 
@@ -731,7 +843,7 @@ _all_refs = (None, _cell_refs, _class_refs, _co_refs, _dict_refs, _enum_refs,
              _type_refs, _weak_refs)
 
 
- # type-specific length functions
+# type-specific length functions
 
 def _len(obj):
     '''Safe len().
@@ -743,7 +855,7 @@ def _len(obj):
 
 
 def _len_array(obj):
-    '''Array length in bytes.
+    '''Array length (in bytes!).
     '''
     return len(obj) * obj.itemsize
 
@@ -757,8 +869,8 @@ def _len_bytearray(obj):
 def _len_code(obj):  # see .../Lib/test/test_sys.py
     '''Length of code object (stack and variables only).
     '''
-    return (obj.co_stacksize + obj.co_nlocals + _len(obj.co_freevars) +
-            _len(obj.co_cellvars) - 1)
+    return (obj.co_stacksize + obj.co_nlocals +
+           _len(obj.co_freevars) + _len(obj.co_cellvars) - 1)
 
 
 def _len_dict(obj):
@@ -794,7 +906,7 @@ def _len_int(obj):
     if obj:
         n, i = 1, abs(obj)
         if i > _digitmax:
-             # no log(x[, base]) in Python 2.2
+            # no log(x[, base]) in Python 2.2
             n += int(log(i) * _digitlog)
     else:  # zero
         n = 0
@@ -816,7 +928,7 @@ def _len_list(obj):
     '''Length of list (estimate).
     '''
     n = len(obj)
-     # estimate over-allocation
+    # estimate over-allocation
     if n > 8:
         n += 6 + (n >> 3)
     elif n:
@@ -828,6 +940,12 @@ def _len_module(obj):
     '''Module length.
     '''
     return _len(obj.__dict__)  # _len(dir(obj))
+
+
+def _len_numpy(obj):
+    '''NumPy array, matrix, etc. length (in bytes!).
+    '''
+    return obj.nbytes  # == obj.size * obj.itemsize
 
 
 def _len_set(obj):
@@ -871,10 +989,10 @@ def _len_unicode(obj):
     return len(obj) + 1
 
 
-_all_lengs = (None, _len, _len_array, _len_bytearray, _len_code, _len_dict,
-              _len_frame, _len_int, _len_iter, _len_list, _len_module,
-              _len_set, _len_slice, _len_slots, _len_struct, _len_unicode)
-
+_all_lens = (None, _len, _len_array, _len_bytearray, _len_code,
+                   _len_dict, _len_frame, _len_int, _len_iter,
+                   _len_list, _len_module, _len_numpy, _len_set,
+                   _len_slice, _len_slots, _len_struct, _len_unicode)
 
 # more private functions and classes
 
@@ -902,21 +1020,22 @@ class _Claskey(object):
         return r
     __repr__ = __str__
 
- # For most objects, the object type is used as the key in the
- # _typedefs dict further below, except class and type objects
- # and old-style instances.  Those are wrapped with separate
- # _Claskey or _Instkey instances to be able (1) to distinguish
- # instances of different old-style classes by class, (2) to
- # distinguish class (and type) instances from class (and type)
- # definitions for new-style classes and (3) provide similar
- # results for repr() and str() of new- and old-style classes
- # and instances.
+
+# For most objects, the object type is used as the key in the
+# _typedefs dict further below, except class and type objects
+# and old-style instances.  Those are wrapped with separate
+# _Claskey or _Instkey instances to be able (1) to distinguish
+# instances of different old-style classes by class, (2) to
+# distinguish class (and type) instances from class (and type)
+# definitions for new-style classes and (3) provide similar
+# results for repr() and str() of new- and old-style classes
+# and instances.
 
 _claskeys = {}  # [id(obj)] = _Claskey()
 
 
 def _claskey(obj, style):
-    '''Wrap an old- or new-style class object.
+    '''Wraps an old- or new-style class object.
     '''
     i = id(obj)
     k = _claskeys.get(i, None)
@@ -924,7 +1043,9 @@ def _claskey(obj, style):
         _claskeys[i] = k = _Claskey(obj, style)
     return k
 
-try:  # no Class- and InstanceType in Python 3.0
+
+try:  # MCCABE 19
+    # no Class- and InstanceType in Python 3+
     _Types_ClassType = Types.ClassType
     _Types_InstanceType = Types.InstanceType
 
@@ -937,13 +1058,14 @@ try:  # no Class- and InstanceType in Python 3.0
             self._obj = obj  # XXX Weakref.ref(obj)
 
         def __str__(self):
-            return '<class %s.%s%s>' % (self._obj.__module__, self._obj.__name__, _old_style)
+            t = _moduleof(self._obj), self._obj.__name__, _old_style
+            return '<class %s.%s%s>' % t
         __repr__ = __str__
 
     _instkeys = {}  # [id(obj)] = _Instkey()
 
     def _instkey(obj):
-        '''Wrap an old-style class (instance).
+        '''Wraps an old-style class (instance).
         '''
         i = id(obj)
         k = _instkeys.get(i, None)
@@ -976,16 +1098,16 @@ try:  # no Class- and InstanceType in Python 3.0
             k = _claskey(obj, _new_style)
         return k
 
-except AttributeError:  # Python 3.0
+except AttributeError:  # Python 3+
 
-    def _keytuple(obj):
+    def _keytuple(obj):  # PYCHOK expected
         '''Return class and instance keys for a class.
         '''
         if type(obj) is _Type_type:  # isclass(obj):
             return _claskey(obj, _new_style), obj
         return None, None  # not a class
 
-    def _objkey(obj):
+    def _objkey(obj):  # PYCHOK expected
         '''Return the key for any object.
         '''
         k = type(obj)
@@ -1014,11 +1136,13 @@ class _Slots(tuple):
     pass
 
 
- # kinds of _Typedefs
+# kinds of _Typedefs
 _i = _intern
 _all_kinds = (_kind_static, _kind_dynamic, _kind_derived, _kind_ignored, _kind_inferred) = (
-    _i('static'), _i('dynamic'), _i('derived'), _i('ignored'), _i('inferred'))
+                _i('static'), _i('dynamic'), _i('derived'), _i('ignored'), _i('inferred'))
 del _i
+
+_Not_vari = ''  # non-variable item size
 
 
 class _Typedef(object):
@@ -1027,16 +1151,17 @@ class _Typedef(object):
     __slots__ = {
         'base': 0,     # basic size in bytes
         'item': 0,     # item size in bytes
-        'leng': None,  # or _len_...() function
+        'alen': None,  # or _len_...() function
         'refs': None,  # or _..._refs() function
         'both': None,  # both data and code if True, code only if False
         'kind': None,  # _kind_... value
-        'type': None}  # original type
+        'type': None,  # original type
+        'vari': None}  # item size attr name or _Not_vari
 
     def __init__(self, **kwds):
         self.reset(**kwds)
 
-    def __lt__(self, unused):  # for Python 3.0
+    def __lt__(self, unused):  # for Python 3+
         return True
 
     def __repr__(self):
@@ -1044,7 +1169,7 @@ class _Typedef(object):
 
     def __str__(self):
         t = [str(self.base), str(self.item)]
-        for f in (self.leng, self.refs):
+        for f in (self.alen, self.refs):
             if f:
                 t.append(f.__name__)
             else:
@@ -1056,7 +1181,7 @@ class _Typedef(object):
     def args(self):  # as args tuple
         '''Return all attributes as arguments tuple.
         '''
-        return (self.base, self.item, self.leng, self.refs,
+        return (self.base, self.item, self.alen, self.refs,
                 self.both, self.kind, self.type)
 
     def dup(self, other=None, **kwds):
@@ -1073,9 +1198,10 @@ class _Typedef(object):
         '''Return the aligned flat size.
         '''
         s = self.base
-        if self.leng and self.item > 0:  # include items
-            s += self.leng(obj) * self.item
-        s = _getsizeof(obj, s)
+        if self.alen and self.item > 0:  # include items
+            s += self.alen(obj) * self.item
+        if _getsizeof:  # _getsizeof prevails
+            s = _getsizeof(obj, s)
         if mask:  # align
             s = (s + mask) & ~mask
         return s
@@ -1083,23 +1209,27 @@ class _Typedef(object):
     def format(self):
         '''Return format dict.
         '''
+        i = self.item
+        if self.vari:
+            i = 'var'
         c = n = ''
         if not self.both:
             c = ' (code only)'
-        if self.leng:
-            n = ' (%s)' % _nameof(self.leng)
-        return dict(base=self.base, item=self.item, leng=n, code=c,
+        if self.alen:
+            n = ' (%s)' % _nameof(self.alen)
+        return dict(base=self.base, item=i, alen=n, code=c,
                     kind=self.kind)
 
     def kwds(self):
         '''Return all attributes as keywords dict.
         '''
         return dict(base=self.base, item=self.item,
-                    leng=self.leng, refs=self.refs,
-                    both=self.both, kind=self.kind, type=self.type)
+                    alen=self.alen, refs=self.refs,
+                    both=self.both, kind=self.kind,
+                    type=self.type, vari=self.vari)
 
     def save(self, t, base=0, heap=False):
-        '''Save this typedef plus its class typedef.
+        '''Saves this typedef plus its class typedef.
         '''
         c, k = _keytuple(t)
         if k and k not in _typedefs:  # instance key
@@ -1119,18 +1249,18 @@ class _Typedef(object):
             raise KeyError('asizeof typedef %r bad: %r %r' % (self, (c, k), self.both))
 
     def set(self, safe_len=False, **kwds):
-        '''Set one or more attributes.
+        '''Sets one or more attributes.
         '''
         if kwds:  # double check
             d = self.kwds()
             d.update(kwds)
             self.reset(**d)
         if safe_len and self.item:
-            self.leng = _len
+            self.alen = _len
 
-    def reset(self, base=0, item=0, leng=None, refs=None,
-              both=True, kind=None, type=None):
-        '''Reset all specified attributes.
+    def reset(self, base=0, item=0, alen=None, refs=None,
+                    both=True, kind=None, type=None, vari=_Not_vari):
+        '''Resets all specified attributes.
         '''
         if base < 0:
             raise ValueError('invalid option: %s=%r' % ('base', base))
@@ -1140,11 +1270,11 @@ class _Typedef(object):
             raise ValueError('invalid option: %s=%r' % ('item', item))
         else:
             self.item = item
-        if leng in _all_lengs:  # XXX or _callable(leng)
-            self.leng = leng
+        if alen in _all_lens:  # XXX or _iscallable(alen)
+            self.alen = alen
         else:
-            raise ValueError('invalid option: %s=%r' % ('leng', leng))
-        if refs in _all_refs:  # XXX or _callable(refs)
+            raise ValueError('invalid option: %s=%r' % ('alen', alen))
+        if refs in _all_refs:  # XXX or _iscallable(refs)
             self.refs = refs
         else:
             raise ValueError('invalid option: %s=%r' % ('refs', refs))
@@ -1157,23 +1287,27 @@ class _Typedef(object):
         else:
             raise ValueError('invalid option: %s=%r' % ('kind', kind))
         self.type = type
+        self.vari = vari or _Not_vari
+        if str(self.vari) != self.vari:
+            raise ValueError('invalid option: %s=%r' % ('vari', vari))
 
 
 _typedefs = {}  # [key] = _Typedef()
 
 
-def _typedef_both(t, base=0, item=0, leng=None, refs=None, kind=_kind_static, heap=False):
-    '''Add new typedef for both data and code.
+def _typedef_both(t, base=0, item=0, alen=None, refs=None,
+                     kind=_kind_static, heap=False, vari=_Not_vari):
+    '''Adds new typedef for both data and code.
     '''
     v = _Typedef(base=_basicsize(t, base=base), item=_itemsize(t, item),
-                 refs=refs, leng=leng,
-                 both=True, kind=kind, type=t)
+                 refs=refs, alen=alen,
+                 both=True, kind=kind, type=t, vari=vari)
     v.save(t, base=base, heap=heap)
     return v  # for _dict_typedef
 
 
 def _typedef_code(t, base=0, refs=None, kind=_kind_static, heap=False):
-    '''Add new typedef for code only.
+    '''Adds new typedef for code only.
     '''
     v = _Typedef(base=_basicsize(t, base=base),
                  refs=refs,
@@ -1181,47 +1315,75 @@ def _typedef_code(t, base=0, refs=None, kind=_kind_static, heap=False):
     v.save(t, base=base, heap=heap)
     return v  # for _dict_typedef
 
- # static typedefs for data and code types
+
+# static typedefs for data and code types
 _typedef_both(complex)
 _typedef_both(float)
-_typedef_both(list, refs=_seq_refs, leng=_len_list, item=_sizeof_Cvoidp)  # sizeof(PyObject*)
-_typedef_both(tuple, refs=_seq_refs, leng=_len, item=_sizeof_Cvoidp)  # sizeof(PyObject*)
+_typedef_both(list, refs=_seq_refs, alen=_len_list, item=_sizeof_Cvoidp)  # sizeof(PyObject*)
+_typedef_both(tuple, refs=_seq_refs, alen=_len, item=_sizeof_Cvoidp)  # sizeof(PyObject*)
 _typedef_both(property, refs=_prop_refs)
 _typedef_both(type(Ellipsis))
 _typedef_both(type(None))
 
- # _Slots is a special tuple, see _Slots.__doc__
+# _Slots is a special tuple, see _Slots.__doc__
 _typedef_both(_Slots, item=_sizeof_Cvoidp,
-              leng=_len_slots,  # length less one
+              alen=_len_slots,  # length less one
               refs=None,  # but no referents
               heap=True)  # plus head
 
- # dict, dictproxy, dict_proxy and other dict-like types
-_dict_typedef = _typedef_both(dict, item=_sizeof_CPyDictEntry, leng=_len_dict, refs=_dict_refs)
+# dict, dictproxy, dict_proxy and other dict-like types
+_dict_typedef = _typedef_both(dict, item=_sizeof_CPyDictEntry, alen=_len_dict, refs=_dict_refs)
 try:  # <type dictproxy> only in Python 2.x
-    _typedef_both(Types.DictProxyType, item=_sizeof_CPyDictEntry, leng=_len_dict, refs=_dict_refs)
-except AttributeError:  # XXX any class __dict__ is <type dict_proxy> in Python 3.0?
-    _typedef_both(type(_Typedef.__dict__), item=_sizeof_CPyDictEntry, leng=_len_dict, refs=_dict_refs)
- # other dict-like classes and types may be derived or inferred,
- # provided the module and class name is listed here (see functions
- # adict, _isdictclass and _infer_dict for further details)
+    _typedef_both(Types.DictProxyType, item=_sizeof_CPyDictEntry, alen=_len_dict, refs=_dict_refs)
+except AttributeError:  # XXX any class __dict__ is <type dict_proxy> in Python 3+?
+    _typedef_both(type(_Typedef.__dict__), item=_sizeof_CPyDictEntry, alen=_len_dict, refs=_dict_refs)
+# other dict-like classes and types may be derived or inferred,
+# provided the module and class name is listed here (see functions
+# adict, _isdictclass and _infer_dict for further details)
 _dict_classes = {'UserDict': ('IterableUserDict', 'UserDict'),
                  'weakref': ('WeakKeyDictionary', 'WeakValueDictionary')}
 try:  # <type module> is essentially a dict
     _typedef_both(Types.ModuleType, base=_dict_typedef.base,
                   item=_dict_typedef.item + _sizeof_CPyModuleObject,
-                  leng=_len_module, refs=_module_refs)
+                  alen=_len_module, refs=_module_refs)
 except AttributeError:  # missing
     pass
 
- # newer or obsolete types
+_getsizeof_excls = ()  # to adjust _getsizeof
+
+
+def _getsizeof_excls_add(typ):
+    global _getsizeof_excls
+    if typ not in _getsizeof_excls:
+        _getsizeof_excls += (typ,)
+
+
+# newer or obsolete types
 try:
     from array import array  # array type
-    _typedef_both(array, leng=_len_array, item=_sizeof_Cbyte)
-    if _getsizeof_bugs:
-        _getsizeof = _getsizeof_exclude(_getsizeof, array)
+
+    def _array_kwds(obj):
+        if hasattr(obj, 'itemsize'):
+            v = 'itemsize'
+        else:
+            v = _Not_vari
+        # since item size varies by the array data type, set
+        # itemsize to 1 byte and use _len_array in bytes; note,
+        # function itemsize returns the actual size in bytes
+        # and function alen returns the length in number of items
+        return dict(alen=_len_array, item=_sizeof_Cbyte, vari=v)
+
+    _typedef_both(array, **_array_kwds(array('d', [])))
+
+    v = sys.version_info
+    _array_excl = (v[0] == 2 and v < (2, 7, 4)) or \
+                  (v[0] == 3 and v < (3, 2, 4))
+    if _array_excl:  # see function _typedef below
+        _getsizeof_excls_add(array)
+
+    del v
 except ImportError:  # missing
-    pass
+    _array_excl = array = None  # see function _typedef below
 
 try:  # bool has non-zero __itemsize__ in 3.0
     _typedef_both(bool)
@@ -1229,40 +1391,40 @@ except NameError:  # missing
     pass
 
 try:  # ignore basestring
-    _typedef_both(basestring, leng=None)
+    _typedef_both(basestring, alen=None)
 except NameError:  # missing
     pass
 
 try:
     if isbuiltin(buffer):  # Python 2.2
-        _typedef_both(type(buffer('')), item=_sizeof_Cbyte, leng=_len)  # XXX len in bytes?
+        _typedef_both(type(buffer('')), item=_sizeof_Cbyte, alen=_len)  # XXX len in bytes?
     else:
-        _typedef_both(buffer, item=_sizeof_Cbyte, leng=_len)  # XXX len in bytes?
+        _typedef_both(buffer, item=_sizeof_Cbyte, alen=_len)  # XXX len in bytes?
 except NameError:  # missing
     pass
 
 try:
-    _typedef_both(bytearray, item=_sizeof_Cbyte, leng=_len_bytearray)
+    _typedef_both(bytearray, item=_sizeof_Cbyte, alen=_len_bytearray)
 except NameError:  # bytearray new in 2.6, 3.0
     pass
 try:
     if type(bytes) is not type(str):  # bytes is str in 2.6, bytes new in 2.6, 3.0
-        _typedef_both(bytes, item=_sizeof_Cbyte, leng=_len)  # bytes new in 2.6, 3.0
+        _typedef_both(bytes, item=_sizeof_Cbyte, alen=_len)  # bytes new in 2.6, 3.0
 except NameError:  # missing
     pass
-try:  # XXX like bytes
-    _typedef_both(str8, item=_sizeof_Cbyte, leng=_len)  # str8 new in 2.6, 3.0
-except NameError:  # missing
-    pass
+# try:  # XXX like bytes
+#    _typedef_both(str8, item=_sizeof_Cbyte, alen=_len)  # PYCHOK str8 new in 2.6, 3.0
+# except NameError:  # missing
+#     pass
 
 try:
     _typedef_both(enumerate, refs=_enum_refs)
 except NameError:  # missing
     pass
 
-try:  # Exception is type in Python 3.0
+try:  # Exception is type in Python 3+
     _typedef_both(Exception, refs=_exc_refs)
-except:  # missing
+except Exception:  # missing
     pass
 
 try:
@@ -1271,11 +1433,11 @@ except NameError:  # missing
     pass
 
 try:
-    _typedef_both(frozenset, item=_sizeof_Csetentry, leng=_len_set, refs=_seq_refs)
+    _typedef_both(frozenset, item=_sizeof_Csetentry, alen=_len_set, refs=_seq_refs)
 except NameError:  # missing
     pass
 try:
-    _typedef_both(set, item=_sizeof_Csetentry, leng=_len_set, refs=_seq_refs)
+    _typedef_both(set, item=_sizeof_Csetentry, alen=_len_set, refs=_seq_refs)
 except NameError:  # missing
     pass
 
@@ -1285,10 +1447,10 @@ except AttributeError:  # missing
     pass
 
 try:  # if long exists, it is multi-precision ...
-    _typedef_both(long, item=_sizeof_Cdigit, leng=_len_int)
+    _typedef_both(long, item=_sizeof_Cdigit, alen=_len_int)
     _typedef_both(int)  # ... and int is fixed size
-except NameError:  # no long, only multi-precision int in Python 3.0
-    _typedef_both(int, item=_sizeof_Cdigit, leng=_len_int)
+except NameError:  # no long, only multi-precision int in Python 3+
+    _typedef_both(int, item=_sizeof_Cdigit, alen=_len_int)
 
 try:  # not callable()
     _typedef_both(Types.MemberDescriptorType)
@@ -1299,6 +1461,45 @@ try:
     _typedef_both(type(NotImplemented))  # == Types.NotImplementedType
 except NameError:  # missing
     pass
+
+_numpy_types = ()
+try:
+    import numpy  # NumPy array, matrix, etc.
+
+    def _numpy_kwds(obj):
+        if _getsizeof:
+            b = _getsizeof(obj, 96) - obj.nbytes
+        else:
+            b = 96  # 96..144 typical __basicsize__?
+        # since item size depends on the nympy data type, set
+        # itemsize to 1 byte and use _len_numpy in bytes; note,
+        # function itemsize returns the actual size in bytes,
+        # function alen returns the length in number of items
+        return dict(base=b, item=_sizeof_Cbyte,  # not obj.itemsize
+                            alen=_len_numpy,
+                            vari='itemsize')
+
+    for d in (numpy.array(range(0)), numpy.arange(0),
+              numpy.matrix(range(0)), numpy.ma.masked_array([])):
+        t = type(d)
+        if t not in _numpy_types:
+            _numpy_types += (t,)
+            if _isnumpy(d):  # double check
+                _typedef_both(t, **_numpy_kwds(d))
+            else:
+                raise AssertionError('not %s: %r' % ('numpy', d))
+
+    # sizing numpy 1.13 arrays works fine, but 1.8 and older
+    # appears to suffer from sys.getsizeof() bug like array
+    v = tuple(map(int, numpy.__version__.split('.')))
+    _numpy_excl = v < (1, 9, 0)
+    if _numpy_excl:  # see function _typedef below
+        for t in _numpy_types:
+            _getsizeof_excls_add(t)
+
+    del numpy, d, t, v
+except ImportError:
+    _numpy_excl = False  # see function _typedef below
 
 try:
     _typedef_both(range)
@@ -1315,26 +1516,26 @@ except NameError:  # missing
     pass
 
 try:
-    _typedef_both(slice, item=_sizeof_Cvoidp, leng=_len_slice)  # XXX worst-case itemsize?
+    _typedef_both(slice, item=_sizeof_Cvoidp, alen=_len_slice)  # XXX worst-case itemsize?
 except NameError:  # missing
     pass
 
 try:
     from os import stat
-    _typedef_both(type(stat(curdir)), refs=_stat_refs)     # stat_result
+    _typedef_both(type(stat(curdir)), refs=_stat_refs)  # stat_result
 except ImportError:  # missing
     pass
 
 try:
     from os import statvfs
     _typedef_both(type(statvfs(curdir)), refs=_statvfs_refs,  # statvfs_result
-                  item=_sizeof_Cvoidp, leng=_len)
+                  item=_sizeof_Cvoidp, alen=_len)
 except ImportError:  # missing
     pass
 
 try:
     from struct import Struct  # only in Python 2.5 and 3.0
-    _typedef_both(Struct, item=_sizeof_Cbyte, leng=_len_struct)  # len in bytes
+    _typedef_both(Struct, item=_sizeof_Cbyte, alen=_len_struct)  # len in bytes
 except ImportError:  # missing
     pass
 
@@ -1344,16 +1545,15 @@ except AttributeError:  # missing
     pass
 
 try:
-    _typedef_both(unicode, leng=_len_unicode, item=_sizeof_Cunicode)
-    _typedef_both(str, leng=_len, item=_sizeof_Cbyte)  # 1-byte char
+    _typedef_both(unicode, alen=_len_unicode, item=_sizeof_Cunicode)
+    _typedef_both(str, alen=_len, item=_sizeof_Cbyte)  # 1-byte char
 except NameError:  # str is unicode
-    _typedef_both(str, leng=_len_unicode, item=_sizeof_Cunicode)
+    _typedef_both(str, alen=_len_unicode, item=_sizeof_Cunicode)
 
 try:  # <type 'KeyedRef'>
     _typedef_both(Weakref.KeyedRef, refs=_weak_refs, heap=True)  # plus head
 except AttributeError:  # missing
     pass
-
 
 try:  # <type 'weakproxy'>
     _typedef_both(Weakref.ProxyType)
@@ -1365,7 +1565,7 @@ try:  # <type 'weakref'>
 except AttributeError:  # missing
     pass
 
- # some other, callable types
+# some other, callable types
 _typedef_code(object, kind=_kind_ignored)
 _typedef_code(super, kind=_kind_ignored)
 _typedef_code(_Type_type, kind=_kind_ignored)
@@ -1393,23 +1593,26 @@ try:  # <type 'weakcallableproxy'>
 except AttributeError:  # missing
     pass
 
- # any type-specific iterators
+# any type-specific iterators
 s = [_items({}), _keys({}), _values({})]
 try:  # reversed list and tuples iterators
     s.extend([reversed([]), reversed(())])
 except NameError:  # missing
     pass
+
 try:  # range iterator
     s.append(xrange(1))
 except NameError:  # missing
     pass
+
 try:  # callable-iterator
     from re import finditer
     s.append(finditer('', ''))
 except ImportError:  # missing
     pass
+
 for t in _values(_typedefs):
-    if t.type and t.leng:
+    if t.type and t.alen:
         try:  # create an (empty) instance
             s.append(t.type())
         except TypeError:
@@ -1417,39 +1620,58 @@ for t in _values(_typedefs):
 for t in s:
     try:
         i = iter(t)
-        _typedef_both(type(i), leng=_len_iter, refs=_iter_refs, item=0)  # no itemsize!
+        _typedef_both(type(i), alen=_len_iter, refs=_iter_refs, item=0)  # no itemsize!
     except (KeyError, TypeError):  # ignore non-iterables, duplicates, etc.
         pass
 del i, s, t
 
 
-def _typedef(obj, derive=False, infer=False):
-    '''Create a new typedef for an object.
+if _getsizeof_excls and _getsizeof:
+    # workaround the sys.getsizeof (and numpy?) bug
+    def _wraps(sys_sizeof):
+        def _getsizeof_wrap(obj, *default):
+            if isinstance(obj, _getsizeof_excls):
+                try:
+                    return default[0]
+                except IndexError:
+                    raise TypeError('no default')
+            else:
+                return sys_sizeof(obj, *default)
+        return _getsizeof_wrap
+
+    _getsizeof = _wraps(_getsizeof)
+    del _wraps
+
+
+def _typedef(obj, derive=False, frames=False, infer=False):  # MCCABE 25
+    '''Creates a new typedef for an object.
     '''
     t = type(obj)
     v = _Typedef(base=_basicsize(t, obj=obj),
                  kind=_kind_dynamic, type=t)
-  ##_printf('new %r %r/%r %s', t, _basicsize(t), _itemsize(t), _repr(dir(obj)))
+#   _printf('new %r %r/%r %s', t, _basicsize(t), _itemsize(t), _repr(dir(obj)))
     if ismodule(obj):  # handle module like dict
         v.dup(item=_dict_typedef.item + _sizeof_CPyModuleObject,
-              leng=_len_module,
+              alen=_len_module,
               refs=_module_refs)
-    elif isframe(obj):
+    elif _isframe(obj):
         v.set(base=_basicsize(t, base=_sizeof_CPyFrameObject, obj=obj),
               item=_itemsize(t),
-              leng=_len_frame,
+              alen=_len_frame,
               refs=_frame_refs)
+        if not frames:  # ignore frames
+            v.set(kind=_kind_ignored)
     elif iscode(obj):
         v.set(base=_basicsize(t, base=_sizeof_CPyCodeObject, obj=obj),
               item=_sizeof_Cvoidp,
-              leng=_len_code,
+              alen=_len_code,
               refs=_co_refs,
               both=False)  # code only
-    elif _callable(obj):
+    elif _iscallable(obj):
         if isclass(obj):  # class or type
             v.set(refs=_class_refs,
                   both=False)  # code only
-            if getattr(obj, '__module__', None) in _builtin_modules:
+            if _moduleof(obj) in _builtin_modules:
                 v.set(kind=_kind_ignored)
         elif isbuiltin(obj):  # function or method
             v.set(both=False,  # code only
@@ -1461,7 +1683,7 @@ def _typedef(obj, derive=False, infer=False):
             v.set(refs=_im_refs,
                   both=False)  # code only
         elif isclass(t):  # callable instance, e.g. SCons,
-             # handle like any other instance further below
+            # handle like any other instance further below
             v.set(item=_itemsize(t), safe_len=True,
                   refs=_inst_refs)  # not code only!
         else:
@@ -1474,7 +1696,15 @@ def _typedef(obj, derive=False, infer=False):
         v.set(item=_itemsize(t), refs=_cell_refs)
     elif _isnamedtuple(obj):
         v.set(refs=_namedtuple_refs)
-    elif getattr(obj, '__module__', None) in _builtin_modules:
+    elif _isnumpy(obj):  # NumPy data
+        v.set(**_numpy_kwds(obj))
+        if _numpy_excl:
+            _getsizeof_excls_add(t)
+    elif array and isinstance(obj, array):
+        v.set(**_array_kwds(obj))
+        if _array_excl:
+            _getsizeof_excls_add(t)
+    elif _moduleof(obj) in _builtin_modules:
         v.set(kind=_kind_ignored)
     else:  # assume an instance of some class
         if derive:
@@ -1498,11 +1728,11 @@ def _typedef(obj, derive=False, infer=False):
 class _Prof(object):
     '''Internal type profile class.
     '''
-    total = 0     # total size
-    high = 0     # largest size
+    total = 0      # total size
+    high = 0       # largest size
     number = 0     # number of (unique) objects
     objref = None  # largest object (weakref)
-    weak = False # objref is weakref(object)
+    weak = False   # objref is weakref(object)
 
     def __cmp__(self, other):
         if self.total < other.total:
@@ -1515,7 +1745,7 @@ class _Prof(object):
             return +1
         return 0
 
-    def __lt__(self, other):  # for Python 3.0
+    def __lt__(self, other):  # for Python 3+
         return self.__cmp__(other) < 0
 
     def format(self, clip=0, grand=None):
@@ -1536,7 +1766,7 @@ class _Prof(object):
                     plural=p, total=t)
 
     def update(self, obj, size):
-        '''Update this profile.
+        '''Updates this profile.
         '''
         self.number += 1
         self.total += size
@@ -1548,20 +1778,22 @@ class _Prof(object):
                 self.objref, self.weak = obj, False
 
 
- # public classes
+# public classes
 
 class Asized(object):
-    '''Store the results of an **asized** object
-       in these 4 attributes:
+    '''Stores the results of an **asized** object in the following
+    4 attributes:
 
-         *size*  -- total size of the object
+        *size* -- total size of the object (including referents)
 
-         *flat*  -- flat size of the object
+        *flat* -- flat size of the object
 
-         *name*  -- name or ``repr`` of the object
+        *name* -- name or ``repr`` of the object
 
-         *refs*  -- tuple containing an **Asized** instance for each referent
+        *refs* -- tuple containing an **Asized** instance for each referent
     '''
+    __slots__ = ('flat', 'name', 'refs', 'size')
+
     def __init__(self, size, flat, refs=(), name=None):
         self.size = size  # total size
         self.flat = flat  # flat size
@@ -1572,49 +1804,56 @@ class Asized(object):
         return 'size %r, flat %r, refs[%d], name %r' % (
             self.size, self.flat, len(self.refs), self.name)
 
-    def get(self, name):
+    def format(self, format='%(name)s size=%(size)d flat=%(flat)d',
+                     detail=-1, order_by='size', indent=''):
+        '''Formats the size information of the object and of all sized
+        referents as a string.
+
+            *format='%(name)s...'* -- specifies the format string per
+            instance, valid interpolation parameters are 'name', 'size'
+            and 'flat'
+
+            *detail=-1* -- detail level up to which referents are
+            printed (-1 for unlimited)
+
+            *order_by='size'* -- sort order of referents, valid choices
+            are 'name', 'size' or 'flat'
+
+            *indent=''* -- optional indentation
+        '''
+        lines = [indent + (format % dict(size=self.size, flat=self.flat,
+                                         name=self.name))]
+        if detail and self.refs:
+            refs = sorted(self.refs, key=lambda x: getattr(x, order_by),
+                                     reverse=order_by in ('size', 'flat'))
+            lines += [ref.format(format=format, detail=detail-1, order_by=order_by,
+                                 indent=indent+'    ') for ref in refs]
+        return '\n'.join(lines)
+
+    def get(self, name, dflt=None):
+        '''Return the named referent (or *dflt* if not found).
+        '''
         for ref in self.refs:
             if name == ref.name:
                 return ref
-        return None
-
-    def format(self, format='%(name)s size=%(size)d flat=%(flat)d', depth=-1,
-               order_by='size', indent=''):
-        '''
-        Format the size information of the object and of all sized referents as
-        a string.
-
-        :param format: Specifies the format per instance with 'name', 'size'
-            and 'flat' as valid interpolation parameters.
-        :param depth: Up to which recursion level the referents are printed.
-        :param order_by: Control sort order of referents. Valid options are
-            'name', 'size' and 'flat'.
-        '''
-        representation = indent + (format % self.__dict__)
-        if depth != 0:
-            indent = indent + '    '
-            reverse = (order_by in ('size', 'flat'))
-            refs = sorted(self.refs, key=lambda x: getattr(x, order_by), reverse=reverse)
-            refs = [ref.format(format, depth-1, order_by, indent)
-                    for ref in refs]
-            representation = '\n'.join([representation] + refs)
-        return representation
+        return dflt
 
 
 class Asizer(object):
-    '''Sizer state and options.
+    '''State and options to accumulate sizes.
     '''
     _align_ = 8
     _clip_ = 80
     _code_ = False
     _derive_ = False
     _detail_ = 0  # for Asized only
+    _frames_ = False
     _infer_ = False
     _limit_ = 100
     _stats_ = 0
 
     _cutoff = 0  # in percent
-    _depth = 0  # recursion depth
+    _depth = 0  # deepest recursion
     _duplicate = 0
     _excl_d = None  # {}
     _ign_d = _kind_ignored
@@ -1629,23 +1868,30 @@ class Asizer(object):
     _stream = None  # IO stream for printing
 
     def __init__(self, **opts):
-        '''See method **reset** for the available options.
+        '''New **Asizer** accumulator.
+
+        See this module documentation for more details.  See method
+        **reset** for all available options and defaults.
         '''
         self._excl_d = {}
         self.reset(**opts)
 
-    def _printf(self, *args, **kwargs):
-        '''Print to configured stream if any is specified and the file argument
-        is not already set for this specific call.
+    def _printf(self, fmt, *args, **print3opts):
+        '''Prints to sys.stdout or the configured stream if any is
+        specified and if the file keyword argument is not already
+        set in the **print3opts for this specific call.
         '''
-        if self._stream and not kwargs.get('file'):
-            kwargs['file'] = self._stream
-        _printf(*args, **kwargs)
+        if self._stream and not print3opts.get('file', None):
+            if args:
+                fmt = fmt % args
+            _printf(fmt, file=self._stream, **print3opts)
+        else:
+            _printf(fmt, *args, **print3opts)
 
     def _clear(self):
-        '''Clear state.
+        '''Clears state.
         '''
-        self._depth = 0   # recursion depth
+        self._depth = 0   # recursion depth reached
         self._duplicate = 0
         self._incl = ''  # or ' (incl. code)'
         self._missed = 0   # due to errors
@@ -1679,12 +1925,12 @@ class Asizer(object):
         '''
         return _repr(obj, clip=self._clip_)
 
-    def _sizer(self, obj, deep, sized):
-        '''Size an object, recursively.
+    def _sizer(self, obj, deep, sized):  # MCCABE 16
+        '''Sizes an object, recursively.
         '''
         s, f, i = 0, 0, id(obj)
-         # skip obj if seen before
-         # or if ref of a given obj
+        # skip obj if seen before
+        # or if ref of a given obj
         if i in self._seen:
             if deep:
                 self._seen[i] += 1
@@ -1701,30 +1947,31 @@ class Asizer(object):
                 v = _typedefs.get(k, None)
                 if not v:  # new typedef
                     _typedefs[k] = v = _typedef(obj, derive=self._derive_,
-                                                infer=self._infer_)
+                                                     frames=self._frames_,
+                                                      infer=self._infer_)
                 if (v.both or self._code_) and v.kind is not self._ign_d:
                     s = f = v.flat(obj, self._mask)  # flat size
                     if self._profile:  # profile type
                         self._prof(k).update(obj, s)
-                     # recurse, but not for nested modules
-                    if v.refs and deep < self._limit_ and not (deep and ismodule(obj)):
-                         # add sizes of referents
+                    # recurse, but not for nested modules
+                    if v.refs and deep < self._limit_ \
+                              and not (deep and ismodule(obj)):
+                        # add sizes of referents
                         r, z, d = v.refs, self._sizer, deep + 1
                         if sized and deep < self._detail_:
-                             # use named referents
+                            # use named referents
                             for o in r(obj, True):
                                 if isinstance(o, _NamedRef):
                                     t = z(o.ref, d, sized)
-                                    t.name = o.name
+                                    t.name = o.name  # PYCHOK _sizer
                                 else:
                                     t = z(o, d, sized)
                                     t.name = self._nameof(o)
                                 rs.append(t)
-                                s += t.size
+                                s += t.size  # PYCHOK _sizer
                         else:  # no sum(<generator_expression>) in Python 2.2
-                            for o in r(obj, False):
-                                s += z(o, d, None)
-                         # recursion depth
+                            s += sum(z(o, d, None) for o in r(obj, False))
+                        # recursion depth reached
                         if self._depth < d:
                             self._depth = d
             self._seen[i] += 1
@@ -1735,9 +1982,9 @@ class Asizer(object):
         return s
 
     def _sizes(self, objs, sized=None):
-        '''Return the size or an **Asized** instance for each
-           given object and the total size.  The total
-           includes the size of duplicates only once.
+        '''Return the size or an **Asized** instance for each given
+        object and the total size.  The total includes the size of
+        any duplicates only once.
         '''
         self.exclude_refs(*objs)  # skip refs to objs
         s, t = {}, []
@@ -1757,12 +2004,13 @@ class Asizer(object):
         return s, tuple(t)
 
     def asized(self, *objs, **opts):
-        '''Size each object and return an **Asized** instance with
-           size information and referents up to the given detail
-           level (and with modified options, see method **set**).
+        '''Sizes each object and returns an **Asized** instance with
+        size information and *referents* up to the given detail level
+        (and with modified options, see method **set**).
 
-           If only one object is given, the return value is the
-           **Asized** instance for that object.
+        If only one object is given, the return value is the **Asized**
+        instance for that object.  The **Asized** size of duplicate and
+        ignored objects will be zero.
         '''
         if opts:
             self.set(**opts)
@@ -1772,8 +2020,8 @@ class Asizer(object):
         return t
 
     def asizeof(self, *objs, **opts):
-        '''Return the combined size of the given objects
-           (with modified options, see method **set**).
+        '''Return the combined size of the given objects (with modified
+        options, see method **set**).
         '''
         if opts:
             self.set(**opts)
@@ -1781,20 +2029,28 @@ class Asizer(object):
         return s
 
     def asizesof(self, *objs, **opts):
-        '''Return the individual sizes of the given objects
-           (with modified options, see method  **set**).
+        '''Return the individual sizes of the given objects (with
+        modified options, see method  **set**).
+
+        The size of duplicate and ignored objects will be zero.
         '''
         if opts:
             self.set(**opts)
         _, t = self._sizes(objs, None)
         return t
 
-    def exclude_refs(self, *objs):
-        '''Exclude any references to the specified objects from sizing.
+    def _get_duplicate(self):
+        '''Number of duplicate objects seen so far.
+        '''
+        return self._duplicate
+    duplicate = property(_get_duplicate, doc=_get_duplicate.__doc__)
 
-           While any references to the given objects are excluded, the
-           objects will be sized if specified as positional arguments
-           in subsequent calls to methods **asizeof** and **asizesof**.
+    def exclude_refs(self, *objs):
+        '''Excludes any references to the specified objects from sizing.
+
+        While any references to the given objects are excluded, the
+        objects will be sized if specified as positional arguments in
+        subsequent calls to methods **asizeof** and **asizesof**.
         '''
         for o in objs:
             self._seen.setdefault(id(o), 0)
@@ -1802,25 +2058,33 @@ class Asizer(object):
     def exclude_types(self, *objs):
         '''Exclude the specified object instances and types from sizing.
 
-           All instances and types of the given objects are excluded,
-           even objects specified as positional arguments in subsequent
-           calls to methods **asizeof** and **asizesof**.
+        All instances and types of the given objects are excluded, even
+        objects specified as positional arguments in subsequent calls
+        to methods **asizeof** and **asizesof**.
         '''
         for o in objs:
             for t in _keytuple(o):
                 if t and t not in self._excl_d:
                     self._excl_d[t] = 0
 
-    def print_profiles(self, w=0, cutoff=0, **print3opts):
-        '''Print the profiles above *cutoff* percentage.
-
-               *w=0*           -- indentation for each line
-
-               *cutoff=0*      -- minimum percentage printed
-
-               *print3options* -- print options, ala Python 3.0
+    def _get_missed(self):
+        '''Number of objects missed due to errors.
         '''
-         # get the profiles with non-zero size or count
+        return self._missed
+    missed = property(_get_missed, doc=_get_missed.__doc__)
+
+    def print_profiles(self, w=0, cutoff=0, **print3opts):
+        '''Prints the profiles above *cutoff* percentage.
+
+        The available options and defaults are:
+
+            *w=0* -- indentation for each line
+
+            *cutoff=0* -- minimum percentage printed
+
+            *print3opts* -- some keyword arguments, like Python 3+ print
+        '''
+        # get the profiles with non-zero size or count
         t = [(v, k) for k, v in _items(self._profs) if v.total > 0 or v.number > 1]
         if (len(self._profs) - len(t)) < 9:  # just show all
             t = [(v, k) for k, v in _items(self._profs)]
@@ -1848,21 +2112,23 @@ class Asizer(object):
                 self._printf('%+*d %r object%s', w, z, 'zero', _plural(z), **print3opts)
 
     def print_stats(self, objs=(), opts={}, sized=(), sizes=(), stats=3.0, **print3opts):
-        '''Print the statistics.
+        '''Prints the statistics.
 
-               *w=0*           -- indentation for each line
+        The available options and defaults are:
 
-               *objs=()*       -- optional, list of objects
+            *w=0* -- indentation for each line
 
-               *opts={}*       -- optional, dict of options used
+            *objs=()* -- optional, list of objects
 
-               *sized=()*      -- optional, tuple of **Asized** instances returned
+            *opts={}* -- optional, dict of options used
 
-               *sizes=()*      -- optional, tuple of sizes returned
+            *sized=()* -- optional, tuple of **Asized** instances returned
 
-               *stats=0.0*     -- print stats, see function **asizeof**
+            *sizes=()* -- optional, tuple of sizes returned
 
-               *print3options* -- print options, as in Python 3.0
+            *stats=0.0* -- print stats, see function **asizeof**
+
+            *print3opts* -- some keyword arguments, like Python 3+ print
         '''
         s = min(opts.get('stats', stats) or 0, self._stats_)
         if s > 0:  # print stats
@@ -1872,7 +2138,7 @@ class Asizer(object):
             o = _kwdstr(**opts)
             if o and objs:
                 c = ', '
-             # print header line(s)
+            # print header line(s)
             if sized and objs:
                 n = len(objs)
                 if n > 1:
@@ -1889,22 +2155,23 @@ class Asizer(object):
                 if objs:
                     t = self._repr(objs)
                 self._printf('%sasizeof(%s%s%s) ...', linesep, t, c, o, **print3opts)
-             # print summary
+            # print summary
             self.print_summary(w=w, objs=objs, **print3opts)
             if s > 1:  # print profile
-                c = int(s - int(s)) * 100
-                self.print_profiles(w=w, cutoff=c, **print3opts)
+                self.print_profiles(w=w, cutoff=_c100(s), **print3opts)
                 if s > 2:  # print typedefs
                     self.print_typedefs(w=w, **print3opts)
 
     def print_summary(self, w=0, objs=(), **print3opts):
-        '''Print the summary statistics.
+        '''Prints the summary statistics.
 
-               *w=0*            -- indentation for each line
+        The available options and defaults are:
 
-               *objs=()*        -- optional, list of objects
+            *w=0* -- indentation for each line
 
-               *print3options*  -- print options, as in Python 3.0
+            *objs=()* -- optional, list of objects
+
+            *print3opts* -- some keyword arguments, like Python 3+ print
         '''
         self._printf('%*d bytes%s%s', w, self._total, _SI(self._total), self._incl, **print3opts)
         if self._mask:
@@ -1926,46 +2193,110 @@ class Asizer(object):
         if self._missed > 0:
             self._printf('%*d object%s missed', w, self._missed, _plural(self._missed), **print3opts)
         if self._depth > 0:
-            self._printf('%*d recursion depth', w, self._depth, **print3opts)
+            self._printf('%*d deepest recursion', w, self._depth, **print3opts)
 
     def print_typedefs(self, w=0, **print3opts):
-        '''Print the types and dict tables.
+        '''Prints the types and dict tables.
 
-               *w=0*            -- indentation for each line
+        The available options and defaults are:
 
-               *print3options*  -- print options, as in Python 3.0
+            *w=0* -- indentation for each line
+
+            *print3opts* -- some keyword arguments, like Python 3+ print
         '''
         for k in _all_kinds:
-             # XXX Python 3.0 doesn't sort type objects
+            # XXX Python 3+ doesn't sort type objects
             t = [(self._prepr(a), v) for a, v in _items(_typedefs) if v.kind == k and (v.both or self._code_)]
             if t:
                 self._printf('%s%*d %s type%s:  basicsize, itemsize, _len_(), _refs()',
                              linesep, w, len(t), k, _plural(len(t)), **print3opts)
                 for a, v in sorted(t):
                     self._printf('%*s %s:  %s', w, '', a, v, **print3opts)
-         # dict and dict-like classes
+        # dict and dict-like classes
         t = sum(len(v) for v in _values(_dict_classes))
         if t:
             self._printf('%s%*d dict/-like classes:', linesep, w, t, **print3opts)
             for m, v in _items(_dict_classes):
                 self._printf('%*s %s:  %s', w, '', m, self._prepr(v), **print3opts)
 
-    def set(self, align=None, code=None, detail=None, limit=None, stats=None):
-        '''Set some options.  See also **reset**.
+    def _get_total(self):
+        '''Total size (in bytes) accumulated so far.
+        '''
+        return self._total
+    total = property(_get_total, doc=_get_total.__doc__)
 
-               *align*   -- size alignment
+    def reset(self, align=8, clip=80, code=False, derive=False,  # PYCHOK too many args
+              detail=0, frames=False, ignored=True, infer=False,
+              limit=100, stats=0, stream=None, **kwds):
+        '''Resets the options, state, etc.
 
-               *code*    -- incl. (byte)code size
+        The available options and defaults are:
 
-               *detail*  -- Asized refs level
+            *align=8* -- size alignment
 
-               *limit*   -- recursion limit
+            *clip=80* -- clip repr() strings
 
-               *stats*   -- print statistics, see function **asizeof**
+            *code=False* -- incl. (byte)code size
+
+            *derive=False* -- derive from super type
+
+            *detail=0* -- **Asized** refs level
+
+            *frames=False* -- ignore frame objects
+
+            *ignored=True* -- ignore certain types
+
+            *infer=False* -- try to infer types
+
+            *limit=100* -- recursion limit
+
+            *stats=0.0* -- print statistics, see function **asizeof**
+
+            *stream=None* -- output stream for printing
+
+        See function **asizeof** for a description of the options.
+        '''
+        if kwds:
+            t = _plural(len(kwds)), _kwdstr(**kwds)
+            raise KeyError('invalid option%s: %s' % t)
+        # options
+        self._align_ = align
+        self._clip_ = clip
+        self._code_ = code
+        self._derive_ = derive
+        self._detail_ = detail  # for Asized only
+        self._frames_ = frames
+        self._infer_ = infer
+        self._limit_ = limit
+        self._stats_ = stats
+        self._stream = stream
+        if ignored:
+            self._ign_d = _kind_ignored
+        else:
+            self._ign_d = None
+        # clear state
+        self._clear()
+        self.set(align=align, code=code, stats=stats)
+
+    def set(self, align=None, code=None, detail=None, frames=None, limit=None, stats=None):
+        '''Sets some options.  See also method **reset**.
 
         Any options not set remain unchanged from the previous setting.
+        The available options are:
+
+            *align* -- size alignment
+
+            *code* -- incl. (byte)code size
+
+            *detail* -- **Asized** refs level
+
+            *frames* -- size or ignore frame objects
+
+            *limit* -- recursion limit
+
+            *stats* -- print statistics, see function **asizeof**
         '''
-         # adjust
+        # adjust
         if align is not None:
             self._align_ = align
             if align > 1:
@@ -1980,91 +2311,27 @@ class Asizer(object):
                 self._incl = ' (incl. code)'
         if detail is not None:
             self._detail_ = detail
+        if frames is not None:
+            self._frames_ = frames
         if limit is not None:
             self._limit_ = limit
         if stats is not None:
+            if stats < 0:
+                raise ValueError('invalid option: %s=%r' % ('stats', stats))
             self._stats_ = s = int(stats)
-            self._cutoff = (stats - s) * 100
-            if s > 1:  # profile types
-                self._profile = True
-            else:
-                self._profile = False
-
-    def _get_duplicate(self):
-        '''Number of duplicate objects.
-        '''
-        return self._duplicate
-    duplicate = property(_get_duplicate, doc=_get_duplicate.__doc__)
-
-    def _get_missed(self):
-        '''Number of objects missed due to errors.
-        '''
-        return self._missed
-    missed = property(_get_missed, doc=_get_missed.__doc__)
-
-    def _get_total(self):
-        '''Total size accumulated so far.
-        '''
-        return self._total
-    total = property(_get_total, doc=_get_total.__doc__)
-
-    def reset(self, align=8, clip=80, code=False, derive=False,
-              detail=0, ignored=True, infer=False, limit=100, stats=0,
-              stream=None):
-        '''Reset options, state, etc.
-
-        The available options and default values are:
-
-             *align=8*       -- size alignment
-
-             *clip=80*       -- clip repr() strings
-
-             *code=False*    -- incl. (byte)code size
-
-             *derive=False*  -- derive from super type
-
-             *detail=0*      -- Asized refs level
-
-             *ignored=True*  -- ignore certain types
-
-             *infer=False*   -- try to infer types
-
-             *limit=100*     -- recursion limit
-
-             *stats=0.0*     -- print statistics, see function **asizeof**
-
-             *stream=None*   -- output stream for printing
-
-        See function **asizeof** for a description of the options.
-        '''
-         # options
-        self._align_ = align
-        self._clip_ = clip
-        self._code_ = code
-        self._derive_ = derive
-        self._detail_ = detail  # for Asized only
-        self._infer_ = infer
-        self._limit_ = limit
-        self._stats_ = stats
-        self._stream = stream
-        if ignored:
-            self._ign_d = _kind_ignored
-        else:
-            self._ign_d = None
-         # clear state
-        self._clear()
-        self.set(align=align, code=code, stats=stats)
+            self._cutoff = _c100(stats)
+            self._profile = s > 1  # profile types
 
 
- # public functions
+# public functions
 
 def adict(*classes):
-    '''Install one or more classes to be handled as dict.
+    '''Installs one or more classes to be handled as dict.
     '''
     a = True
     for c in classes:
-         # if class is dict-like, add class
-         # name to _dict_classes[module]
+        # if class is dict-like, add class
+        # name to _dict_classes[module]
         if isclass(c) and _infer_dict(c):
             t = _dict_classes.get(c.__module__, ())
             if c.__name__ not in t:  # extend tuple
@@ -2079,40 +2346,43 @@ _asizer = Asizer()
 
 def asized(*objs, **opts):
     '''Return a tuple containing an **Asized** instance for each
-       object passed as positional argument using the following
-       options.
+    object passed as positional argument.
 
-           *align=8*       -- size alignment
+    The available options and defaults are:
 
-           *clip=80*       -- clip repr() strings
+        *align=8* -- size alignment
 
-           *code=False*    -- incl. (byte)code size
+        *clip=80* -- clip repr() strings
 
-           *derive=False*  -- derive from super type
+        *code=False* -- incl. (byte)code size
 
-           *detail=0*      -- Asized refs level
+        *derive=False* -- derive from super type
 
-           *ignored=True*  -- ignore certain types
+        *detail=0* -- **Asized** refs level
 
-           *infer=False*   -- try to infer types
+        *frames=False* -- ignore frame objects
 
-           *limit=100*     -- recursion limit
+        *ignored=True* -- ignore certain types
 
-           *stats=0.0*     -- print statistics
+        *infer=False* -- try to infer types
 
-       If only one object is given, the return value is the **Asized**
-       instance for that object.  Otherwise, the length of the returned
-       tuple matches the number of given objects.
+        *limit=100* -- recursion limit
 
-       Set *detail* to the desired referents level (recursion depth).
+        *stats=0.0* -- print statistics, see function **asizeof**
 
-       See function **asizeof** for descriptions of the other options.
+    If only one object is given, the return value is the **Asized**
+    instance for that object.  Otherwise, the length of the returned
+    tuple matches the number of given objects.
 
+    The **Asized** size of duplicate and ignored objects will be zero.
+
+    Set *detail* to the desired referents level and *limit* to the
+    maximum recursion depth.
+
+    See function **asizeof** for descriptions of the other options.
     '''
-    if 'all' in opts:
-        raise KeyError('invalid option: %s=%r' % ('all', opts['all']))
+    _asizer.reset(**opts)
     if objs:
-        _asizer.reset(**opts)
         t = _asizer.asized(*objs)
         _asizer.print_stats(objs, opts=opts, sized=t)  # show opts as _kwdstr
         _asizer._clear()
@@ -2122,33 +2392,37 @@ def asized(*objs, **opts):
 
 
 def asizeof(*objs, **opts):
-    '''Return the combined size in bytes of all objects passed as positional arguments.
+    '''Return the combined size (in bytes) of all objects passed
+    as positional arguments.
 
-    The available options and defaults are the following.
+    The available options and defaults are:
 
-         *align=8*       -- size alignment
+        *align=8* -- size alignment
 
-         *all=False*     -- all current objects
+        *all=False* -- all current objects
 
-         *clip=80*       -- clip ``repr()`` strings
+        *clip=80* -- clip ``repr()`` strings
 
-         *code=False*    -- incl. (byte)code size
+        *code=False* -- incl. (byte)code size
 
-         *derive=False*  -- derive from super type
+        *derive=False* -- derive from super type
 
-         *ignored=True*  -- ignore certain types
+        *frames=False* -- ignore frame objects
 
-         *infer=False*   -- try to infer types
+        *ignored=True* -- ignore certain types
 
-         *limit=100*     -- recursion limit
+        *infer=False* -- try to infer types
 
-         *stats=0.0*     -- print statistics
+        *limit=100* -- recursion limit
+
+        *stats=0.0* -- print statistics
 
     Set *align* to a power of 2 to align sizes.  Any value less
     than 2 avoids size alignment.
 
-    All current module, global and stack objects are sized if
-    *all* is True and if no positional arguments are supplied.
+    If *all* is True and if no positional arguments are supplied.
+    size all current gc objects, including module, global and stack
+    frame objects.
 
     A positive *clip* value truncates all repr() strings to at
     most *clip* characters.
@@ -2176,11 +2450,11 @@ def asizeof(*objs, **opts):
     a summary of the number of objects sized and seen, (2) a
     simple profile of the sized objects by type and (3+) up to
     6 tables showing the static, dynamic, derived, ignored,
-    inferred and dict types used, found resp. installed.  The
-    fractional part of the *stats* value (x100) is the cutoff
-    percentage for simple profiles.
+    inferred and dict types used, found respectively installed.
+    The fractional part of the *stats* value (x 100) is the
+    cutoff percentage for simple profiles.
 
-    [4] See the documentation of this module for the definition of flat size.
+    See this module documentation for the definition of flat size.
     '''
     t, p = _objs_opts(objs, **opts)
     if t:
@@ -2194,34 +2468,37 @@ def asizeof(*objs, **opts):
 
 
 def asizesof(*objs, **opts):
-    '''Return a tuple containing the size in bytes of all objects
-       passed as positional arguments using the following options.
+    '''Return a tuple containing the size (in bytes) of all objects
+    passed as positional argments.
 
-           *align=8*       -- size alignment
+    The available options and defaults are:
 
-           *clip=80*       -- clip ``repr()`` strings
+        *align=8* -- size alignment
 
-           *code=False*    -- incl. (byte)code size
+        *clip=80* -- clip ``repr()`` strings
 
-           *derive=False*  -- derive from super type
+        *code=False* -- incl. (byte)code size
 
-           *ignored=True*  -- ignore certain types
+        *derive=False* -- derive from super type
 
-           *infer=False*   -- try to infer types
+        *frames=False* -- ignore frame objects
 
-           *limit=100*     -- recursion limit
+        *ignored=True* -- ignore certain types
 
-           *stats=0.0*     -- print statistics
+        *infer=False* -- try to infer types
 
-       See function **asizeof** for a description of the options.
+        *limit=100* -- recursion limit
 
-       The length of the returned tuple equals the number of given
-       objects.
+        *stats=0.0* -- print statistics
+
+    See function **asizeof** for a description of the options.
+
+    The length of the returned tuple equals the number of given objects.
+
+    The size of duplicate and ignored objects will be zero.
     '''
-    if 'all' in opts:
-        raise KeyError('invalid option: %s=%r' % ('all', opts['all']))
+    _asizer.reset(**opts)
     if objs:  # size given objects
-        _asizer.reset(**opts)
         t = _asizer.asizesof(*objs)
         _asizer.print_stats(objs, opts=opts, sizes=t)  # show opts as _kwdstr
         _asizer._clear()
@@ -2242,30 +2519,50 @@ def _typedefof(obj, save=False, **opts):
     return v
 
 
+def alen(obj, **opts):
+    '''Return the length of an object (in *items*).
+
+    See function **basicsize** for a description of the options.
+    '''
+    n = t = _typedefof(obj, **opts)
+    if t:
+        n = t.alen
+        if n and _iscallable(n):
+            i, v, n = t.item, t.vari, n(obj)
+            if v and i == _sizeof_Cbyte:
+                i = getattr(obj, v, i)
+                if i > _sizeof_Cbyte:
+                    n = n // i
+    return n
+
+
+leng = alen  # for backward comptibility
+
+
 def basicsize(obj, **opts):
     '''Return the basic size of an object (in bytes).
 
-       Valid options and defaults are
+    The available options and defaults are:
 
-           *derive=False*  -- derive type from super type
+        *derive=False* -- derive type from super type
 
-           *infer=False*   -- try to infer types
+        *infer=False* -- try to infer types
 
-           *save=False*    -- save typedef if new
+        *save=False* -- save the type definition if new
     '''
-    v = _typedefof(obj, **opts)
-    if v:
-        v = v.base
-    return v
+    b = _typedefof(obj, **opts)
+    if b:
+        b = b.base
+    return b
 
 
 def flatsize(obj, align=0, **opts):
-    '''Return the flat size of an object (in bytes),
-       optionally aligned to a given power of 2.
+    '''Return the flat size of an object (in bytes), optionally aligned
+    to a given power of 2.
 
-       See function **basicsize** for a description of
-       the other options.  See the documentation of
-       this module for the definition of flat size.
+    See function **basicsize** for a description of all other options.
+
+    See this module documentation for the definition of *flat size*.
     '''
     v = _typedefof(obj, **opts)
     if v:
@@ -2275,73 +2572,86 @@ def flatsize(obj, align=0, **opts):
                 raise ValueError('invalid option: %s=%r' % ('align', align))
         else:
             m = 0
-        v = v.flat(obj, m)
+        v = v.flat(obj, mask=m)
     return v
 
 
 def itemsize(obj, **opts):
     '''Return the item size of an object (in bytes).
 
-       See function **basicsize** for a description of
-       the options.
+    See function **basicsize** for a description of the options.
     '''
-    v = _typedefof(obj, **opts)
-    if v:
-        v = v.item
-    return v
+    i = t = _typedefof(obj, **opts)
+    if t:
+        i, v = t.item, t.vari
+        if v and i == _sizeof_Cbyte:
+            i = getattr(obj, v, i)
+    return i
 
 
-def leng(obj, **opts):
-    '''Return the length of an object (in items).
+def named_refs(obj, **opts):
+    """Returns (a generator for) all named *referents* of an object
+    (re-using functionality from **asizeof**).
 
-       See function **basicsize** for a description of
-       the options.
-    '''
-    v = _typedefof(obj, **opts)
-    if v:
-        v = v.leng
-        if v and _callable(v):
-            v = v(obj)
-    return v
+    See function **basicsize** for a description of the options.
+
+    Does not return un-named *referents*, e.g. objects in a list.
+    """
+    t = _typedefof(obj, **opts)
+    if t:
+        r = t.refs
+        if r and _iscallable(r):
+            for nr in r(obj, True):
+                try:
+                    yield nr.name, nr.ref
+                except AttributeError:
+                    pass
 
 
 def refs(obj, **opts):
-    '''Return (a generator for) specific referents of an
-       object.
+    '''Return (a generator for) specific *referents* of an object.
 
-       See function **basicsize** for a description of
-       the options.
+    See function **basicsize** for a description of the options.
     '''
-    v = _typedefof(obj, **opts)
-    if v:
-        v = v.refs
-        if v and _callable(v):
-            v = v(obj, False)
-    return v
+    r = t = _typedefof(obj, **opts)
+    if t:
+        r = t.refs
+        if r and _iscallable(r):
+            r = r(obj, False)
+    return r
 
 
-def named_refs(obj):
-    """
-    Return all named referents of `obj`. Reuse functionality from asizeof.
-    Does not return referents without a name, e.g. objects in a list.
-    """
-    refs = []
-    v = _typedefof(obj)
-    if v:
-        v = v.refs
-        if v and _callable(v):
-            for ref in v(obj, True):
-                try:
-                    refs.append((ref.name, ref.ref))
-                except AttributeError:
-                    pass
-    return refs
+if __name__ == '__main__':
 
+    if '-types' in sys.argv:  # print static _typedefs
+        n = len(_typedefs)
+        w = len(str(n)) * ' '
+        _printf('%s%d type definitions: %s and %s, kind ... %s', linesep,
+                 n, 'basic-', 'itemsize (alen)', '-type[def]s')
+        for k, v in sorted((_prepr(k), v) for k, v in _items(_typedefs)):
+            s = '%(base)s and %(item)s%(alen)s, %(kind)s%(code)s' % v.format()
+            _printf('%s %s: %s', w, k, s)
 
-# License file from an earlier version of this source file follows:
+    else:
+        if '-gc' in sys.argv:
+            try:
+                import gc  # PYCHOK expected
+                gc.collect()
+            except ImportError:
+                pass
 
-#---------------------------------------------------------------------
-#       Copyright (c) 2002-2008 -- ProphICy Semiconductor, Inc.
+        frames = '-frames' in sys.argv
+
+        # just an example
+        asizeof(all=True, frames=frames, stats=2)  # print summary
+
+    if '-v' in sys.argv:
+        print('\n%s %s (Python %s)' % (__file__, __version__, sys.version.split()[0]))
+
+# License from the initial version of this source file follows:
+
+# --------------------------------------------------------------------
+#       Copyright (c) 2002-2017 -- ProphICy Semiconductor, Inc.
 #                        All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -2373,4 +2683,4 @@ def named_refs(obj):
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
-#---------------------------------------------------------------------
+# --------------------------------------------------------------------

--- a/test/asizeof/test_asizeof.py
+++ b/test/asizeof/test_asizeof.py
@@ -1,6 +1,6 @@
-
 import gc
 import os
+import pprint
 import sys
 import unittest
 import weakref
@@ -30,15 +30,15 @@ class OldFoo:
 
 
 class PseudoDict(object):
-    '''Dict-like object for inferring dictionaries.'''
+    '''Dict-like object for inferring dictionaries'''
 
     def __len__(self):
         return 0
 
-    def get(self, *args, **kwargs):
+    def get(self, *args, **kwds):
         return None
 
-    def has_key(self, *args, **kwargs):
+    def has_key(self, *args):
         return False
 
     def items(self):
@@ -54,8 +54,7 @@ class PseudoDict(object):
 class TypesTest(unittest.TestCase):
 
     def test_generator(self):
-        '''Test integrity of sized generator
-        '''
+        '''Test integrity of sized generator'''
         def infinite_gen():
             i = 1
             while True:
@@ -79,8 +78,7 @@ class TypesTest(unittest.TestCase):
         self.assertEqual(s3, 0)
 
     def test_methods(self):
-        '''Test sizing methods and functions
-        '''
+        '''Test sizing methods and functions'''
         def foo():
             pass
 
@@ -90,25 +88,23 @@ class TypesTest(unittest.TestCase):
         # TODO asserts?
 
     def test_classes(self):
-        '''Test sizing class objects and instances
-        '''
-        self.assert_(asizeof.asizeof(Foo, code=True) > 0)
-        self.assert_(asizeof.asizeof(ThinFoo, code=True) > 0)
-        self.assert_(asizeof.asizeof(OldFoo, code=True) > 0)
+        '''Test sizing class objects and instances'''
+        self.assertTrue(asizeof.asizeof(Foo, code=True) > 0)
+        self.assertTrue(asizeof.asizeof(ThinFoo, code=True) > 0)
+        self.assertTrue(asizeof.asizeof(OldFoo, code=True) > 0)
 
-        self.assert_(asizeof.asizeof(Foo([17,42,59])) > 0)
-        self.assert_(asizeof.asizeof(ThinFoo([17,42,59])) > 0)
-        self.assert_(asizeof.asizeof(OldFoo([17,42,59])) > 0)
+        self.assertTrue(asizeof.asizeof(Foo([17,42,59])) > 0)
+        self.assertTrue(asizeof.asizeof(ThinFoo([17,42,59])) > 0)
+        self.assertTrue(asizeof.asizeof(OldFoo([17,42,59])) > 0)
 
         s1 = asizeof.asizeof(Foo("short"))
         s2 = asizeof.asizeof(Foo("long text ... well"))
-        self.assert_(s2 >= s1)
+        self.assertTrue(s2 >= s1)
         s3 = asizeof.asizeof(ThinFoo("short"))
-        self.assert_(s3 <= s1)
+        self.assertTrue(s3 <= s1)
 
     def test_special_objects(self):
-        '''Test sizing special objects.
-        '''
+        '''Test sizing special objects'''
         module_size = asizeof.asizeof(unittest)
         self.assertTrue(module_size > 0, module_size)
 
@@ -123,6 +119,7 @@ class TypesTest(unittest.TestCase):
         self.assertTrue(set(['__doc__']) <= ref_names, ref_names)
 
     def test_array(self):
+        '''Test array'''
         from array import array
         arr = array('i', [0] * 100)
         arr_size = asizeof.asizeof(arr)
@@ -130,8 +127,7 @@ class TypesTest(unittest.TestCase):
         self.assertTrue(arr_size >= buf_size, (arr_size, buf_size))
 
     def test_weakref(self):
-        '''Test sizing weak references.
-        '''
+        '''Test sizing weak references'''
         alive = Foo('alive')
         aref = weakref.ref(alive)
         dead = Foo('dead')
@@ -147,15 +143,14 @@ class TypesTest(unittest.TestCase):
         refs = asizeof.named_refs(dref)
 
     def test_os_stat(self):
-        '''Test sizing os.stat and os.statvfs objects.
-        '''
+        '''Test sizing os.stat and os.statvfs objects'''
         try:
             stat = os.stat(__file__)
         except Exception:
             pass
         else:
             stat_size = asizeof.asizeof(stat)
-            self.assertTrue(stat_size > 0, stat_size)
+            self.assertTrue(stat_size > 0)  # , stat_size)
             refs = asizeof.named_refs(stat)
             ref_names = set([name for name, _ in refs])
             self.assertTrue(set(['st_mode', 'st_size', 'st_mtime']) <= ref_names, ref_names)
@@ -172,8 +167,7 @@ class TypesTest(unittest.TestCase):
             self.assertTrue(set(['f_bsize', 'f_blocks']) <= ref_names, ref_names)
 
     def test_exception(self):
-        '''Test sizing exceptions.
-        '''
+        '''Test sizing exceptions'''
         try:
             raise Exception("Test exception-sizing.")
         except Exception:
@@ -190,17 +184,15 @@ class TypesTest(unittest.TestCase):
                 del etb
 
     def test_ignore_frame(self):
-        '''Test whether reference cycles are created
-        '''
+        '''Test whether reference cycles are created'''
         gc.collect()
         gc.disable()
-        s = asizeof.asizeof(all=True, code=True)
+        s = asizeof.asizeof(all=True, frames=False, code=True)
         self.assertEqual(gc.collect(), 0)
         gc.enable()
 
     def test_closure(self):
-        '''Test sizing closures.
-        '''
+        '''Test sizing closures'''
         def outer(x):
             def inner():
                 return x
@@ -213,8 +205,7 @@ class TypesTest(unittest.TestCase):
         self.assertTrue(size_closure >= size_data, (size_closure, size_data))
 
     def test_namedtuple(self):
-        '''Test values are included but namedtuple __dict__ isn't.
-        '''
+        '''Test values are included but namedtuple __dict__ isn't'''
         from collections import namedtuple
         Point = namedtuple('Point', ['x', 'y'])
         point = Point(x=11, y=22)
@@ -223,17 +214,56 @@ class TypesTest(unittest.TestCase):
         self.assertTrue('__dict__' not in refs, refs)
         self.assertTrue('11' in refs, refs)
 
-    def test_numpy_array(self):
-        '''Test sizing numpy arrays.
-        '''
+    def test_numpy(self):
+        '''Test sizing numpy arrays, aranges, matrix'''
         try:
-            from numpy import arange
+            import numpy
         except ImportError:
             pass
         else:
-            x = arange(1000)
-            size = asizeof.asizeof(x)
-            self.assertTrue(size > 1000, size)
+            r = numpy.arange(10)
+            self.assertTrue(r.size == 10, r.size)
+            self.assertTrue(r.itemsize > 1, r.itemsize)
+            size = asizeof.asizeof(r)
+            self.assertTrue(size > r.nbytes, (size, r.nbytes))
+
+            a = numpy.array(range(1000))
+            self.assertTrue(a.size == 1000, a.size)
+            self.assertTrue(a.itemsize > 1, a.itemsize)
+            size = asizeof.asizeof(a)
+            self.assertTrue(size > a.nbytes, (size, a.nbytes))
+
+            m = numpy.matrix('1 2 3; 4 5 6')
+            self.assertTrue(m.size == 6, m.size)
+            self.assertTrue(m.itemsize > 1, m.itemsize)
+            size = asizeof.asizeof(m)
+            self.assertTrue(size > m.nbytes, (size, m.nbytes))
+
+            # <https://docs.scipy.org/doc/numpy/glossary.html#term-masked-array>
+            m = numpy.ma.masked_array(range(12))
+            self.assertTrue(m.size == 12, m.size)
+            self.assertTrue(m.itemsize > 1, m.itemsize)
+            size = asizeof.asizeof(m)
+            self.assertTrue(size > m.nbytes, (size, m.nbytes))
+
+            # <https://docs.scipy.org/doc/numpy/glossary.html#term-mask>
+            m = r > 2  # mask == array(dtype=bool)
+            self.assertTrue(m.size == r.size, m.size)
+#           self.assertTrue(m.itemsize == 1, m.itemsize)
+            size = asizeof.asizeof(m)
+            self.assertTrue(size > m.nbytes, (size, m.nbytes))
+
+    def test_private_slots(self):
+        class PrivateSlot(object):
+            __slots__ = ('__data',)
+            def __init__(self, data):
+                self.__data = data
+
+        data = [42] * 100
+        container = PrivateSlot(data)
+        size1 = asizeof.asizeof(container)
+        size2 = asizeof.asizeof(data)
+        self.assertTrue(size1 > size2, (size1, size2))
 
 
 class FunctionTest(unittest.TestCase):
@@ -241,10 +271,9 @@ class FunctionTest(unittest.TestCase):
     '''
 
     def test_asized(self):
-        '''Test asizeof.asized()
-        '''
+        '''Test asizeof.asized()'''
         self.assertEqual(list(asizeof.asized(detail=2)), [])
-        self.assertRaises(KeyError, asizeof.asized, **{'all': True})
+        self.assertRaises(KeyError, asizeof.asized, all=True)
         sized = asizeof.asized(Foo(42), detail=2)
         self.assertEqual(sized.name, 'Foo')
         refs = [ref for ref in sized.refs if ref.name == '__dict__']
@@ -261,22 +290,22 @@ class FunctionTest(unittest.TestCase):
         self.assertEqual(len(sized_objs), 2)
 
     def test_asized_detail(self):
+        '''Test asizeof.asized(detail=)'''
         foo = Foo(42)
         size1 = asizeof.asized(foo, detail=1)
         size2 = asizeof.asized(foo, detail=2)
         self.assertEqual(size1.size, size2.size)
 
     def test_asized_format(self):
-        '''Test Asized.format(depth=x)
-        '''
+        '''Test Asized.format(depth=x)'''
         foo = Foo(42)
         sized1 = asizeof.asized(foo, detail=1)
         sized2 = asizeof.asized(foo, detail=2)
         sized1_no = sized1.format('%(name)s', order_by='name')
-        sized1_d1 = sized1.format('%(name)s', depth=1, order_by='name')
-        sized1_d2 = sized1.format('%(name)s', depth=2, order_by='name')
-        sized2_d1 = sized2.format('%(name)s', depth=1, order_by='name')
-        sized2_d2 = sized2.format('%(name)s', depth=2, order_by='name')
+        sized1_d1 = sized1.format('%(name)s', detail=1, order_by='name')
+        sized1_d2 = sized1.format('%(name)s', detail=2, order_by='name')
+        sized2_d1 = sized2.format('%(name)s', detail=1, order_by='name')
+        sized2_d2 = sized2.format('%(name)s', detail=2, order_by='name')
         self.assertEqual(sized1_no, "Foo\n    __class__\n    __dict__")
         self.assertEqual(sized1_no, sized1_d1)
         self.assertEqual(sized1_no, sized1_d2)
@@ -284,10 +313,9 @@ class FunctionTest(unittest.TestCase):
         self.assertNotEqual(sized2_d1, sized2_d2)
 
     def test_asizesof(self):
-        '''Test asizeof.asizesof()
-        '''
+        '''Test asizeof.asizesof()'''
         self.assertEqual(list(asizeof.asizesof()), [])
-        self.assertRaises(KeyError, asizeof.asizesof, **{'all': True})
+        self.assertRaises(KeyError, asizeof.asizesof, all=True)
 
         objs = [Foo(42), ThinFoo("spam"), OldFoo(67)]
         sizes = list(asizeof.asizesof(*objs))
@@ -303,11 +331,10 @@ class FunctionTest(unittest.TestCase):
         asizer_sizes = sizer.asizesof(*objs)
         self.assertEqual(list(asizer_sizes), sizes)
         code_sizes = sizer.asizesof(*objs, **dict(code=True))
-        self.failIfEqual(list(code_sizes), sizes)
+        self.assertNotEqual(list(code_sizes), sizes)
 
     def test_asizeof(self):
-        '''Test asizeof.asizeof()
-        '''
+        '''Test asizeof.asizeof()'''
         self.assertEqual(asizeof.asizeof(), 0)
 
         objs = [Foo(42), ThinFoo("spam"), OldFoo(67)]
@@ -319,8 +346,7 @@ class FunctionTest(unittest.TestCase):
         self.assertEqual(total, sum, (total, sum))
 
     def test_asizer_limit(self):
-        '''Test limit setting for Asizer.
-        '''
+        '''Test limit setting for Asizer'''
         objs = [Foo(42), ThinFoo("spam"), OldFoo(67)]
         sizer = [asizeof.Asizer() for _ in range(4)]
         for limit, asizer in enumerate(sizer):
@@ -330,84 +356,116 @@ class FunctionTest(unittest.TestCase):
         self.assertTrue(limit_sizes[1] < limit_sizes[2], limit_sizes)
         self.assertTrue(limit_sizes[2] < limit_sizes[3], limit_sizes)
 
+    def test_alen(self):
+        '''Test asizeof.alen() formerly .leng()'''
+        l = [1,2,3,4]
+        s = "spam"
+        self.assertTrue(asizeof.alen(l) >= len(l), asizeof.alen(l))
+        self.assertEqual(asizeof.alen(tuple(l)), len(l))
+        self.assertTrue(asizeof.alen(set(l)) >= len(set(l)))
+        self.assertTrue(asizeof.alen(s) >= len(s))
+
+        # Python 3.0 ints behave like Python 2.x longs.  However,
+        # alen() reports None for old ints and >=1 for new ints/longs.
+        self.assertTrue(asizeof.alen(42) in [None, 1], asizeof.alen(42))
+        base = 2
+        try:
+            base = long(base)
+        except NameError:  # Python 3+
+            pass
+        self.assertEqual(asizeof.alen(base**8-1), 1)
+        self.assertEqual(asizeof.alen(base**16-1), 1)
+        self.assertTrue(asizeof.alen(base**32-1) >= 1)
+        self.assertTrue(asizeof.alen(base**64-1) >= 2)
+
+        try:
+            import array
+        except ImportError:
+            pass
+        else:
+            a = array.array('d', (1.0, 2, 3, 1e63))
+            self.assertEqual(asizeof.alen(a), len(a), asizeof.alen(a))
+
+        try:
+            import numpy
+        except ImportError:
+            pass
+        else:
+            a = numpy.array(range(10), dtype=numpy.complex)
+            self.assertEqual(asizeof.alen(a), a.size, asizeof.alen(a))
+
+            r = numpy.arange(100)
+            self.assertEqual(asizeof.alen(r), r.size, asizeof.alen(r))
+
+            m = numpy.matrix('1 2 3; 4 5 6')
+            self.assertEqual(asizeof.alen(m), m.size, asizeof.alen(m))
+
     def test_basicsize(self):
-        '''Test asizeof.basicsize()
-        '''
-        objects = [1, '', 'a', True, None]
-        for o in objects:
+        '''Test asizeof.basicsize()'''
+        for o in [1, '', 'a', True, None]:
             self.assertEqual(asizeof.basicsize(o), type(o).__basicsize__)
-        objects = [[], (), {}]
-        for o in objects:
-            self.assertEqual(asizeof.basicsize(o) - asizeof._sizeof_CPyGC_Head,
-                type(o).__basicsize__)
+        for o in [[], (), {}]:
+            self.assertEqual(asizeof.basicsize(o), type(o).__basicsize__ + asizeof._sizeof_CPyGC_Head)
         l1 = [1,2,3,4]
         l2 = ["spam",2,3,4,"eggs",6,7,8]
         self.assertEqual(asizeof.basicsize(l1), asizeof.basicsize(l2))
 
     def test_itemsize(self):
-        '''Test asizeof.itemsize()
-        '''
-        objects = [1, True, None, ()]
-        for o in objects:
+        '''Test asizeof.itemsize()'''
+        for o in  [1, True, None, ()]:
             self.assertEqual(asizeof.itemsize(o), type(o).__itemsize__)
-        itemsizes = [({}, asizeof._sizeof_CPyDictEntry),
-                     (set(), asizeof._sizeof_Csetentry),
-                     ]
-        for o, itemsize in itemsizes:
+        for o, itemsize in [({},    asizeof._sizeof_CPyDictEntry),
+                            (set(), asizeof._sizeof_Csetentry)]:
             self.assertEqual(asizeof.itemsize(o), itemsize)
 
-    def test_leng(self):
-        '''Test asizeof.leng()
-        '''
-        l = [1,2,3,4]
-        s = "spam"
-        self.assert_(asizeof.leng(l) >= len(l), asizeof.leng(l))
-        self.assertEqual(asizeof.leng(tuple(l)), len(l))
-        self.assert_(asizeof.leng(set(l)) >= len(set(l)))
-        self.assert_(asizeof.leng(s) >= len(s))
-
-        # Python 3.0 ints behave like Python 2.x longs. leng() reports
-        # None for old ints and >=1 for new ints/longs.
-        self.assert_(asizeof.leng(42) in [None, 1], asizeof.leng(42))
-        base = 2
         try:
-            base = long(base)
-        except NameError: # Python3.0
+            import array
+        except ImportError:
             pass
-        self.assertEqual(asizeof.leng(base**8-1), 1)
-        self.assertEqual(asizeof.leng(base**16-1), 1)
-        self.assert_(asizeof.leng(base**32-1) >= 1)
-        self.assert_(asizeof.leng(base**64-1) >= 2)
+        else:
+            a = array.array('d', (1.0, 2, 3, 1e63))
+            self.assertEqual(asizeof.itemsize(a), a.itemsize, asizeof.itemsize(a))
+
+        try:
+            import numpy
+        except ImportError:
+            pass
+        else:
+            a = numpy.array(range(10), dtype=numpy.complex)
+            self.assertEqual(asizeof.itemsize(a), a.itemsize, asizeof.itemsize(a))
+
+            r = numpy.arange(100)
+            self.assertEqual(asizeof.itemsize(r), r.itemsize, asizeof.itemsize(r))
+
+            m = numpy.matrix('1 2 3; 4 5 6')
+            self.assertEqual(asizeof.itemsize(m), m.itemsize, asizeof.itemsize(m))
 
     def test_refs(self):
-        '''Test asizeof.refs()
-        '''
+        '''Test asizeof.refs()'''
         f = Foo(42)
         refs = list(asizeof.refs(f))
-        self.assert_(len(refs) >= 1, len(refs))
-        self.assert_({'data': 42} in refs, refs)
+        self.assertTrue(len(refs) >= 1, len(refs))
+        self.assertTrue({'data': 42} in refs, refs)
 
         f = OldFoo(42)
         refs = list(asizeof.refs(f))
-        self.assert_(len(refs) >= 1, len(refs))
-        self.assert_({'odata': 42} in refs, refs)
+        self.assertTrue(len(refs) >= 1, len(refs))
+        self.assertTrue({'odata': 42} in refs, refs)
 
         f = ThinFoo(42)
         refs = list(asizeof.refs(f))
-        self.assert_(len(refs) >= 2, len(refs))
-        self.assert_(42 in refs, refs)
-        self.assert_(('tdata',) in refs, refs) # slots
+        self.assertTrue(len(refs) >= 2, len(refs))
+        self.assertTrue(42 in refs, refs)
+        self.assertTrue(('tdata',) in refs, refs)  # slots
 
     def test_exclude_types(self):
-        '''Test Asizer.exclude_types().
-        '''
+        '''Test Asizer.exclude_types()'''
         sizer = asizeof.Asizer()
         sizer.exclude_types(Foo)
         self.assertEqual(sizer.asizeof(Foo('ignored')), 0)
 
     def test_asizer(self):
-        '''Test Asizer properties.
-        '''
+        '''Test Asizer properties'''
         sizer = asizeof.Asizer()
         obj = 'unladen swallow'
         mutable = [obj]
@@ -418,8 +476,7 @@ class FunctionTest(unittest.TestCase):
         self.assertEqual(sizer.total, asizeof.asizeof(obj, mutable))
 
     def test_adict(self):
-        '''Test asizeof.adict()
-        '''
+        '''Test asizeof.adict()'''
         pdict = PseudoDict()
         size1 = asizeof.asizeof(pdict)
         asizeof.adict(PseudoDict)
@@ -427,21 +484,16 @@ class FunctionTest(unittest.TestCase):
         # TODO: come up with useful assertions
         self.assertEqual(size1, size2)
 
-    def test_private_slots(self):
-        class PrivateSlot(object):
-            __slots__ = ('__data',)
-            def __init__(self, data):
-                self.__data = data
 
-        data = [42] * 100
-        container = PrivateSlot(data)
-        size1 = asizeof.asizeof(container)
-        size2 = asizeof.asizeof(data)
-        self.assertTrue(size1 > size2, (size1, size2))
+class _DevNull(object):
+    def flush(self):
+        pass
+    def write(self, text):
+        pass
 
 
 def _repr(o):
-    return repr(o)
+    return pprint.pformat(o)
 
 
 class AsizeofDemos(unittest.TestCase):
@@ -453,19 +505,15 @@ class AsizeofDemos(unittest.TestCase):
 
     MAX = sys.getrecursionlimit()
 
-    class DevNull(object):
-        def write(self, text):
-            pass
-
     def setUp(self):
         self._stdout = sys.stdout
-        sys.stdout = self.DevNull()
+        sys.stdout = _DevNull()
 
     def tearDown(self):
         sys.stdout = self._stdout
 
-    def _printf(self, *args):
-        pass # XXX
+    def _printf(self, fmt, *args):
+        print(fmt % args)
 
     def _print_asizeof(self, obj, infer=False, stats=0):
         a = [_repr(obj),]
@@ -474,16 +522,17 @@ class AsizeofDemos(unittest.TestCase):
         self._printf(" asizeof(%s) is %d, %d, %d", *a)
 
     def _print_functions(self, obj, name=None, align=8, detail=MAX, code=False, limit=MAX,
-                              opt='', **unused):
+                               opt='', **unused):
         if name:
             self._printf('%sasizeof functions for %s ... %s', os.linesep, name, opt)
         self._printf('%s(): %s', ' basicsize', asizeof.basicsize(obj))
         self._printf('%s(): %s', ' itemsize',  asizeof.itemsize(obj))
-        self._printf('%s(): %r', ' leng',      asizeof.leng(obj))
-        self._printf('%s(): %s', ' refs',     _repr(asizeof.refs(obj)))
+        self._printf('%s(): %r', ' alen',      asizeof.alen(obj))
+        if opt != '-stack':
+            self._printf('%s(): %s', ' refs', _repr(asizeof.refs(obj)))
         self._printf('%s(): %s', ' flatsize',  asizeof.flatsize(obj, align=align))  # , code=code
-        self._printf('%s(): %s', ' asized',           asizeof.asized(obj, align=align, detail=detail, code=code, limit=limit))
-      ##_printf('%s(): %s', '.asized',   _asizer.asized(obj, align=align, detail=detail, code=code, limit=limit))
+        self._printf('%s(): %s', ' asized',    asizeof.asized(obj, align=align, detail=detail, code=code, limit=limit))
+      ##self._printf('%s(): %s', '.asized',   _asizer.asized(obj, align=align, detail=detail, code=code, limit=limit))
 
     class C: pass
 
@@ -616,8 +665,8 @@ class AsizeofDemos(unittest.TestCase):
         for o in (1024, 1000000000,
                   1.0, 1.0e100, 1024, 1000000000,
                   self.MAX, 1 << 32, _L5d, -_L5d, _L17d, -_L17d):
-            self._printf(" asizeof(%s) is %s (%s + %s * %s)", _repr(o), asizeof.asizeof(o, align=0, limit=0),
-                                                         asizeof.basicsize(o), asizeof.leng(o), asizeof.itemsize(o))
+            self._printf(" asizeof(%s) is %s (%s + %s * %s)", repr(o), asizeof.asizeof(o, align=0, limit=0),
+                         asizeof.basicsize(o), asizeof.alen(o), asizeof.itemsize(o))
 
     def test_iterator(self):
         '''Test iterator examples'''
@@ -706,19 +755,18 @@ class AsizeofDemos(unittest.TestCase):
         asizeof.asizeof(limit=self.MAX, code=False, stats=1, *sys.modules.values())
         self._print_functions(sys.modules, 'sys.modules', opt='-sys')
 
-    def test_typedefs(self): # remove?
+    def test_typedefs(self):  # remove?
         '''Test showing all basic _typedefs'''
         t = len(asizeof._typedefs)
         w = len(str(t)) * ' '
-        self._printf('%s%d type definitions: basic- and itemsize (leng), kind ... %s', os.linesep, t, '-type[def]s')
+#       self._printf('%s%d type definitions: basic- and itemsize (alen), kind ... %s', os.linesep, t, '-type[def]s')
         for k, v in sorted((asizeof._prepr(k), v) for k, v in asizeof._items(asizeof._typedefs)):
-            s = '%(base)s and %(item)s%(leng)s, %(kind)s%(code)s' % v.format()
-            self._printf('%s %s: %s', w, k, s)
+            s = '%(base)s and %(item)s%(alen)s, %(kind)s%(code)s' % v.format()
+#           self._printf('%s %s: %s', w, k, s)
 
 
 if __name__ == '__main__':
-
-    suite = unittest.makeSuite([AsizeofTest, TypesTest, FunctionTest, AsizeofDemos], 'test')
-  ##suite.addTest(doctest.DocTestSuite())
-  ##suite.debug()
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    if '-v' in sys.argv[1:]:  # and sys.version_info > (2, 7, 0)
+        unittest.main(verbosity=2)
+    else:
+        unittest.main()


### PR DESCRIPTION
* Updates for numpy, array, getobjects, frames, etc. plus cosmetic changes
* Function leng and attribute .leng have been renamed to alen and .alen, respectively
* Added option frames=False to ignore frame objects. Use frames=True to size frame object as in previous versions.

By Jean Brouwers