### PR TITLE
Fix object filtering by size in muppy.

### DIFF
--- a/pympler/muppy.py
+++ b/pympler/muppy.py
@@ -129,16 +129,16 @@ def filter(objects, Type=None, min=-1, max=-1):
     max -- maximum object size
 
     """
-    res = []
-    if min > max:
+    if min > max and max > -1:
         raise ValueError("minimum must be smaller than maximum")
+
     if Type is not None:
-        res = [o for o in objects if isinstance(o, Type)]
+        objects = [o for o in objects if isinstance(o, Type)]
     if min > -1:
-        res = [o for o in res if getsizeof(o) < min]
+        objects = [o for o in objects if getsizeof(o) > min]
     if max > -1:
-        res = [o for o in res if getsizeof(o) > max]
-    return res
+        objects = [o for o in objects if getsizeof(o) < max]
+    return objects
 
 
 def get_referents(object, level=1):

--- a/test/muppy/test_muppy.py
+++ b/test/muppy/test_muppy.py
@@ -68,9 +68,9 @@ class MuppyTest(unittest.TestCase):
         maximum = 958
         objects = []
         for i in range(1000):
-            rand = random.randint(0,1000)
-            objects.append(' ' * rand)
+            objects.append(' ' * i)
         objects = muppy.filter(objects, min=minimum, max=maximum)
+        self.assert_(len(objects) != 0)
         for o in objects:
             self.assert_(minimum <= getsizeof(o) <= maximum)
 


### PR DESCRIPTION
Previously:
 - Filtering by size could not be done without also filtering by type.
 - Size filtering could not be done open ended (> min), both min and max
   had to be provided.
 - Direction for min and max were backwards.