### PR TITLE
Fix all DeprecationWarning: invalid escape sequence

### DIFF
--- a/pympler/asizeof.py
+++ b/pympler/asizeof.py
@@ -185,7 +185,7 @@ downgrading Pympler to version 0.3.x.
 .. [#bi] ``Type``s and ``class``es are considered built-in if the
      ``__module__`` of the type or class is listed in the private
      ``_builtin_modules``.
-'''
+'''  # PYCHOK OK
 import sys
 if sys.version_info < (2, 6, 0):
     raise NotImplementedError('%s requires Python 2.6 or newer' % ('asizeof',))

--- a/pympler/asizeof.py
+++ b/pympler/asizeof.py
@@ -70,7 +70,7 @@ downgrading Pympler to version 0.3.x.
    Call methods **exclude_refs** and/or **exclude_types** to exclude
    references to respectively instances or types of certain objects.
 
-   Use one of the **print\_...** methods to report the statistics.
+   Use one of the **print\\_...** methods to report the statistics.
 
    An instance of class **Asized** is returned for each object sized
    by the **asized** function or method.
@@ -185,7 +185,7 @@ downgrading Pympler to version 0.3.x.
 .. [#bi] ``Type``s and ``class``es are considered built-in if the
      ``__module__`` of the type or class is listed in the private
      ``_builtin_modules``.
-'''  # PYCHOK '\_' OK
+'''
 import sys
 if sys.version_info < (2, 6, 0):
     raise NotImplementedError('%s requires Python 2.6 or newer' % ('asizeof',))

--- a/pympler/util/bottle.py
+++ b/pympler/util/bottle.py
@@ -3426,8 +3426,8 @@ class StplParser(object):
     # 2: Comments (until end of line, but not the newline itself)
     _re_tok += '|(#.*)'
     # 3,4: Open and close grouping tokens
-    _re_tok += '|([\[\{\(])'
-    _re_tok += '|([\]\}\)])'
+    _re_tok += '|([\\[\\{\\(])'
+    _re_tok += '|([\\]\\}\\)])'
     # 5,6: Keywords that start or continue a python block (only start of line)
     _re_tok += '|^([ \\t]*(?:if|for|while|with|try|def|class)\\b)' \
                '|^([ \\t]*(?:elif|else|except|finally)\\b)'


### PR DESCRIPTION
Hello,

This is a little patch to fix `DeprecationWarning`s about invalid escape sequence.

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>