### PR TITLE
fix print syntax in Python3

### DIFF
--- a/pympler/mprofile.py
+++ b/pympler/mprofile.py
@@ -92,5 +92,5 @@ class MProfiler(object):
 
 if __name__ == "__main__":
     p = MProfiler()
-    p.run("print 'hello'")
+    p.run("print('hello')")
     print(p.memories)


### PR DESCRIPTION
`SyntaxError` in Python3, if run this script directlly.