### PR TITLE
Add compatibility with Django Debug Toolbar 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Compatibility with Django Debug Toolbar 2.x -- Reported by John Carter (#96)
+
+### Removed
+- Compatibility with Django Debug Toolbar 1.x
+
 ## 0.7 - 2019-04-05
 
 ### Added

--- a/pympler/panels.py
+++ b/pympler/panels.py
@@ -58,13 +58,13 @@ class MemoryPanel(Panel):
             self._tracker.track_class(cls)
         self._tracker.create_snapshot('before')
         self.record_stats({'before': ProcessMemoryInfo()})
-
-    def process_response(self, request, response):
+        response = super(MemoryPanel, self).process_request(request)
         self.record_stats({'after': ProcessMemoryInfo()})
         self._tracker.create_snapshot('after')
         stats = self._tracker.stats
         stats.annotate()
         self.record_stats({'stats': stats})
+        return response
 
     def enable_instrumentation(self):
         self._tracker = ClassTracker()


### PR DESCRIPTION
Fix for issue #96 

https://django-debug-toolbar.readthedocs.io/en/latest/changes.html#backwards-incompatible-changes