### PR TITLE
fixed #77: version-dependent import of tree widget

### DIFF
--- a/pympler/refbrowser.py
+++ b/pympler/refbrowser.py
@@ -242,7 +242,10 @@ class FileBrowser(StreamBrowser):
 # remains outside this block. If you try to instantiate it without having
 # Tkinter installed, the import error will be raised.
 try:
-    from idlelib import TreeWidget as _TreeWidget
+    if sys.version_info < (3, 5, 2):
+        from idlelib import TreeWidget as _TreeWidget
+    else:
+        from idlelib import tree as _TreeWidget
 
     class _TreeNode(_TreeWidget.TreeNode):
         """TreeNode used by the InteractiveBrowser.


### PR DESCRIPTION
For python >= 3.5.2, `TreeWidget` has been renamed to `tree`. This introduces a version-dependent import to support all necessary python versions.

Resolves #77