### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/source/tutorials/scons-classtracker.rst
+++ b/doc/source/tutorials/scons-classtracker.rst
@@ -44,7 +44,7 @@ MemStats class provides all we need::
 When SCons starts, ``MemStats`` is instantiated and the `ClassTracker` is
 connected to a number of classes. SCons has predefined spots where it invokes
 its statistics facilities with ``do_append`` being called. This is where
-snapshosts will be taken of all objects tracked so far.
+snapshots will be taken of all objects tracked so far.
 
 Because of the large number of instances, only a summary is printed to the
 console via ``stats.print_summary()`` and the profile data is dumped to a file

--- a/pympler/asizeof.py
+++ b/pympler/asizeof.py
@@ -1491,7 +1491,7 @@ try:  # MCCABE 14
 
     def _numpy_kwds(obj):
         b = _getsizeof(obj, 96) - obj.nbytes  # XXX 96..144 typical?
-        # since item size depends on the nympy data type, set
+        # since item size depends on the numpy data type, set
         # itemsize to 1 byte and use _len_numpy in bytes; note,
         # function itemsize returns the actual size in bytes,
         # function alen returns the length in number of items

--- a/pympler/refbrowser.py
+++ b/pympler/refbrowser.py
@@ -192,7 +192,7 @@ class StreamBrowser(RefBrowser):
                 # print the first branch (on the same line)
                 self._print(tree.children[0], prefix, carryon)
                 for b in range(1, len_children):
-                    # the caryon becomes the prefix for all following children
+                    # the carryon becomes the prefix for all following children
                     prefix = carryon[:-2] + self.cross + self.hline
                     # remove the vlines for any children of last branch
                     if b == (len_children - 1):

--- a/pympler/util/bottle.py
+++ b/pympler/util/bottle.py
@@ -2356,7 +2356,7 @@ class FileUpload(object):
     content_length = HeaderProperty('Content-Length', reader=int, default=-1)
 
     def get_header(self, name, default=None):
-        """ Return the value of a header within the mulripart part. """
+        """ Return the value of a header within the multipart part. """
         return self.headers.get(name, default)
 
     @cached_property


### PR DESCRIPTION
There are small typos in:
- doc/source/tutorials/scons-classtracker.rst
- pympler/asizeof.py
- pympler/refbrowser.py
- pympler/util/bottle.py

Fixes:
- Should read `snapshots` rather than `snapshosts`.
- Should read `numpy` rather than `nympy`.
- Should read `multipart` rather than `mulripart`.
- Should read `carryon` rather than `caryon`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md