### PR TITLE
Add ability to redirect all output to TextIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Require pywin32 on Windows
+- `stream` arguments (of type `TextIO` default to `sys.stdout`) for all 
+   classes that are using `print()` calls for redirecting output to 
+   dedicated IO. `file` arguments for methods that are using `print()`
+   directly - by abcdenis (#18, #27) 
 
 ## 1.0.1 - 2021-12-22
 

--- a/pympler/classtracker.py
+++ b/pympler/classtracker.py
@@ -6,8 +6,8 @@ individual objects or all instances of certain classes. Tracked objects are
 sized recursively to provide an overview of memory distribution between the
 different tracked objects.
 """
-
-from typing import Any, Callable, Dict, IO, List, Optional, Tuple
+import sys
+from typing import Any, Callable, Dict, List, Optional, TextIO, Tuple
 
 from collections import defaultdict
 from functools import partial
@@ -255,7 +255,7 @@ class Snapshot(object):
 
 class ClassTracker(object):
 
-    def __init__(self, stream: Optional[IO] = None):
+    def __init__(self, stream: TextIO = sys.stdout) -> None:
         """
         Creates a new `ClassTracker` object.
 

--- a/pympler/classtracker_stats.py
+++ b/pympler/classtracker_stats.py
@@ -3,7 +3,7 @@ Provide saving, loading and presenting gathered `ClassTracker` statistics.
 """
 
 from typing import (
-    Any, Dict, IO, Iterable, List, Optional, Tuple, TYPE_CHECKING, Union
+    Any, Dict, IO, Iterable, List, Optional, TextIO, Tuple, TYPE_CHECKING, Union
 )
 
 import os
@@ -86,7 +86,7 @@ class Stats(object):
 
     def __init__(self, tracker: 'Optional[ClassTracker]' = None,
                  filename: Optional[str] = None,
-                 stream: Optional[IO] = None):
+                 stream: TextIO = sys.stdout) -> None:
         """
         Initialize the data log structures either from a `ClassTracker`
         instance (argument `tracker`) or a previously dumped file (argument
@@ -96,10 +96,7 @@ class Stats(object):
         :param filename: filename of previously dumped statistics
         :param stream: where to print statistics, defaults to ``sys.stdout``
         """
-        if stream:
-            self.stream = stream
-        else:
-            self.stream = sys.stdout
+        self.stream = stream
         self.tracker = tracker
         self.index = {}  # type: Dict[str, List[TrackedObject]]
         self.snapshots = []  # type: List[Snapshot]

--- a/pympler/mprofile.py
+++ b/pympler/mprofile.py
@@ -4,6 +4,7 @@ Memory usage profiler for Python.
 """
 import inspect
 import sys
+from typing import TextIO
 
 from pympler import muppy
 
@@ -37,7 +38,8 @@ class MProfiler(object):
 
     """
 
-    def __init__(self, codepoints=None, events=None):
+    def __init__(self, codepoints=None, events=None,
+                 stream: TextIO = sys.stdout) -> None:
         """
         keyword arguments:
         codepoints -- a list of points in code to monitor (defaults to all
@@ -47,6 +49,7 @@ class MProfiler(object):
         self.memories = {}
         self.codepoints = codepoints
         self.events = events
+        self.stream = stream
 
     def codepoint_included(self, codepoint):
         """Check if codepoint matches any of the defined codepoints."""
@@ -69,7 +72,7 @@ class MProfiler(object):
             cp = (frame_info[0], frame_info[2], frame_info[1])
             if self.codepoint_included(cp):
                 objects = muppy.get_objects()
-                size = muppy.get_size(objects)
+                size = muppy.get_size(objects, file=self.stream)
                 if cp not in self.memories:
                     self.memories[cp] = [0, 0, 0, 0]
                     self.memories[cp][0] = 1

--- a/pympler/muppy.py
+++ b/pympler/muppy.py
@@ -1,6 +1,6 @@
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
-
+from typing import Any, Callable, Dict, List, Optional, Set, TextIO, Tuple
 import gc
+import sys
 
 from pympler import summary
 from pympler.util import compat
@@ -61,14 +61,14 @@ def get_objects(remove_dups: bool = True, include_frames: bool = False
     return res
 
 
-def get_size(objects: List[Any]) -> int:
+def get_size(objects: List[Any], file: TextIO = sys.stdout) -> int:
     """Compute the total size of all elements in objects."""
     res = 0
     for o in objects:
         try:
             res += getsizeof(o)
         except AttributeError:
-            print("IGNORING: type=%s; o=%s" % (str(type(o)), str(o)))
+            print("IGNORING: type=%s; o=%s" % (str(type(o)), str(o)), file=file)
     return res
 
 
@@ -270,6 +270,6 @@ def _remove_duplicates(objects: List[Any]) -> List[Any]:
     return result
 
 
-def print_summary() -> None:
+def print_summary(file: TextIO = sys.stdout) -> None:
     """Print a summary of all known objects."""
-    summary.print_(summary.summarize(get_objects()))
+    summary.print_(summary.summarize(get_objects()), file=file)

--- a/pympler/refbrowser.py
+++ b/pympler/refbrowser.py
@@ -20,6 +20,7 @@ raised.
 import gc
 import inspect
 import sys
+from typing import TextIO
 
 from pympler import muppy
 from pympler import summary
@@ -66,7 +67,7 @@ class RefBrowser(object):
     """
 
     def __init__(self, rootobject, maxdepth=3, str_func=summary._repr,
-                 repeat=True, stream=None):
+                 repeat=True, stream: TextIO = sys.stdout) -> None:
         """You have to provide the root object used in the refbrowser.
 
         keyword arguments
@@ -208,10 +209,9 @@ class StreamBrowser(RefBrowser):
 class ConsoleBrowser(StreamBrowser):
     """RefBrowser that prints to the console (stdout)."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
+        kwargs.update({'stream': sys.stdout})
         super(ConsoleBrowser, self).__init__(*args, **kwargs)
-        if not self.stream:
-            self.stream = sys.stdout
 
 
 class FileBrowser(StreamBrowser):

--- a/pympler/summary.py
+++ b/pympler/summary.py
@@ -46,6 +46,7 @@ more detailed information at higher verbosity levels than 1.
 import re
 import sys
 import types
+from typing import TextIO
 
 from pympler.util import stringutils
 from sys import getsizeof
@@ -238,7 +239,8 @@ def _format_table(rows, header=True):
             header = False
 
 
-def print_(rows, limit=15, sort='size', order='descending'):
+def print_(rows, limit=15, sort='size', order='descending',
+           file: TextIO = sys.stdout) -> None:
     """Print the rows as a summary.
 
     Keyword arguments:
@@ -248,7 +250,7 @@ def print_(rows, limit=15, sort='size', order='descending'):
 
     """
     for line in format_(rows, limit=limit, sort=sort, order=order):
-        print(line)
+        print(line, file=file)
 
 
 # regular expressions used by _repr to replace default type representations

--- a/pympler/tracker.py
+++ b/pympler/tracker.py
@@ -11,6 +11,8 @@ one time and compare with objects from an earlier time.
 """
 import gc
 import inspect
+import sys
+from typing import TextIO
 
 from pympler import muppy, summary
 from pympler.util import compat
@@ -127,7 +129,8 @@ class SummaryTracker(object):
                     "You cannot provide summary2 without summary1.")
         return summary._sweep(res)
 
-    def print_diff(self, summary1=None, summary2=None):
+    def print_diff(self, summary1=None, summary2=None,
+                   file: TextIO = sys.stdout) -> None:
         """Compute diff between to summaries and print it.
 
         If no summary is provided, the diff from the last to the current
@@ -135,7 +138,7 @@ class SummaryTracker(object):
         to the current summary is used. If summary1 and summary2 are
         provided, the diff between these two is used.
         """
-        summary.print_(self.diff(summary1=summary1, summary2=summary2))
+        summary.print_(self.diff(summary1=summary1, summary2=summary2), file=file)
 
     def format_diff(self, summary1=None, summary2=None):
         """Compute diff between to summaries and return a list of formatted
@@ -173,13 +176,14 @@ class ObjectTracker(object):
     # warning at http://docs.python.org/lib/inspect-stack.html). All ignore
     # lists used need to be emptied so no frame objects remain referenced.
 
-    def __init__(self):
+    def __init__(self, stream: TextIO = sys.stdout) -> None:
         """On initialisation, the current state of objects is stored.
 
         Note that all objects which exist at this point in time will not be
         released until you destroy this ObjectTracker instance.
         """
         self.o0 = self._get_objects(ignore=(inspect.currentframe(),))
+        self.stream = stream
 
     def _get_objects(self, ignore=()):
         """Get all currently existing objects.
@@ -247,7 +251,7 @@ class ObjectTracker(object):
         """
         # ignore this and the caller frame
         for line in self.format_diff(ignore+(inspect.currentframe(),)):
-            print(line)
+            print(line, file=self.stream)
 
     def format_diff(self, ignore=()):
         """Format the diff to the last time the state of objects was measured.

--- a/test/muppy/test_summary.py
+++ b/test/muppy/test_summary.py
@@ -78,18 +78,13 @@ class SummaryTest(unittest.TestCase):
 
     def test_print_diff(self):
         """Test summary can be printed."""
-        try:
-            self._stdout = sys.stdout
-            stream = StringIO()
-            sys.stdout = stream
-            sum1 = summary.summarize(muppy.get_objects())
-            sum2 = summary.summarize(muppy.get_objects())
-            sumdiff = summary.get_diff(sum1, sum2)
-            summary.print_(sumdiff)
-            self.assertIn('str', stream.getvalue())
-            self.assertNotIn("<class 'str", stream.getvalue())
-        finally:
-            sys.stdout = self._stdout
+        stream = StringIO()
+        sum1 = summary.summarize(muppy.get_objects())
+        sum2 = summary.summarize(muppy.get_objects())
+        sumdiff = summary.get_diff(sum1, sum2)
+        summary.print_(sumdiff, file=stream)
+        self.assertIn('str', stream.getvalue())
+        self.assertNotIn("<class 'str", stream.getvalue())
 
 
     def test_subtract(self):


### PR DESCRIPTION
`stream` arguments (of type `TextIO` default to `sys.stdout`) for all
classes that are using `print()` calls for redirecting output to
dedicated IO. `file` arguments for methods that are using `print()`
directly