### PR TITLE
CI: Remove EoL Python, add Python 3.13

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,18 +10,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
     - name: Install system dependencies
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get install -y graphviz idle python3-matplotlib
     - name: Install dependencies


### PR DESCRIPTION
Remove Python 3.6 and 3.7 (both end-of-life for over a year) and add Python 3.13 to the build matrix. Also update to ubuntu-latest (currently 22.04) and checkout v4.

Of course Python 3.6 and 3.7 users can keep using existing pympler releases.