### PR TITLE
Replace unittest.getTestCaseNames usage to support Python 3.13

### DIFF
--- a/test/gui/test_garbage.py
+++ b/test/gui/test_garbage.py
@@ -281,8 +281,10 @@ class GarbageTestCase(unittest.TestCase):
 if __name__ == "__main__":
     suite = unittest.TestSuite()
     tclasses = [GarbageTestCase]
+    loader = unittest.TestLoader()
+    loader.testMethodPrefix = 'test_'
     for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
+        names = loader.getTestCaseNames(tclass)
         suite.addTests(map(tclass, names))
     if not unittest.TextTestRunner().run(suite).wasSuccessful():
         sys.exit(1)

--- a/test/gui/test_web.py
+++ b/test/gui/test_web.py
@@ -192,8 +192,10 @@ class WebGuiTest(unittest.TestCase):
 if __name__ == "__main__":
     suite = unittest.TestSuite()
     tclasses = [WebGuiTest]
+    loader = unittest.TestLoader()
+    loader.testMethodPrefix = 'test_'
     for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
+        names = loader.getTestCaseNames(tclass)
         suite.addTests(map(tclass, names))
     if not unittest.TextTestRunner().run(suite).wasSuccessful():
         sys.exit(1)

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -112,8 +112,10 @@ class ProcessMemoryTests(unittest.TestCase):
 if __name__ == "__main__":
     suite = unittest.TestSuite()
     tclasses = [ ProcessMemoryTests, ]
+    loader = unittest.TestLoader()
+    loader.testMethodPrefix = 'test_'
     for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
+        names = loader.getTestCaseNames(tclass)
         suite.addTests(map(tclass, names))
     if not unittest.TextTestRunner().run(suite).wasSuccessful():
         sys.exit(1)

--- a/test/tracker/test_classtracker.py
+++ b/test/tracker/test_classtracker.py
@@ -420,8 +420,10 @@ if __name__ == "__main__":
                 SnapshotTestCase,
                 TrackerTestCase
                ]
+    loader = unittest.TestLoader()
+    loader.testMethodPrefix = 'test_'
     for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
+        names = loader.getTestCaseNames(tclass)
         suite.addTests(map(tclass, names))
     if not unittest.TextTestRunner().run(suite).wasSuccessful():
         sys.exit(1)

--- a/test/tracker/test_stats.py
+++ b/test/tracker/test_stats.py
@@ -317,8 +317,10 @@ class LogTestCase(unittest.TestCase):
 if __name__ == "__main__":
     suite = unittest.TestSuite()
     tclasses = [ LogTestCase ]
+    loader = unittest.TestLoader()
+    loader.testMethodPrefix = 'test_'
     for tclass in tclasses:
-        names = unittest.getTestCaseNames(tclass, 'test_')
+        names = loader.getTestCaseNames(tclass)
         suite.addTests(map(tclass, names))
     if not unittest.TextTestRunner().run(suite).wasSuccessful():
         sys.exit(1)


### PR DESCRIPTION
In Python 3.13 function `unittest.getTestCaseNames` was removed and instead `unittest.TestLoader.getTestCaseNames` should be used. This PR makes the replacement.

Python 3.13 release notes: [link](https://docs.python.org/3/whatsnew/3.13.html#unittest)