### PR TITLE
Replace unittest.makeSuite usage to support Python 3.13

### DIFF
--- a/test/muppy/test_mprofile.py
+++ b/test/muppy/test_mprofile.py
@@ -42,7 +42,7 @@ class MProfileTest(unittest.TestCase):
 
 
 def suite():
-    suite = unittest.makeSuite(MProfileTest,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(MProfileTest)
     return suite
 
 if __name__ == '__main__':

--- a/test/muppy/test_muppy.py
+++ b/test/muppy/test_muppy.py
@@ -218,7 +218,7 @@ class MuppyTest(unittest.TestCase):
 
 
 def suite():
-    suite = unittest.makeSuite(MuppyTest,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(MuppyTest)
     suite.addTest(doctest.DocTestSuite())
     return suite
 

--- a/test/muppy/test_refbrowser.py
+++ b/test/muppy/test_refbrowser.py
@@ -296,7 +296,7 @@ root-+-branch1-+-a
 __test__ = {"test_print_tree": test_print_tree}
 
 def suite():
-    suite = unittest.makeSuite(TreeTest,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(TreeTest)
     suite.addTest(doctest.DocTestSuite())
     return suite
 

--- a/test/muppy/test_summary.py
+++ b/test/muppy/test_summary.py
@@ -257,7 +257,7 @@ The _print_table function should print a nice, clean table.
 #            "test_print_": test_print_}
 
 def suite():
-    suite = unittest.makeSuite(SummaryTest,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(SummaryTest)
     suite.addTest(doctest.DocTestSuite())
     return suite
 


### PR DESCRIPTION
In Python 3.13 function `unittest.makeSuite` was removed and instead `unittest.TestLoader.loadTestsFromTestCase` should be used. This PR makes the replacement.

Python 3.13 release notes: [link](https://docs.python.org/3/whatsnew/3.13.html#unittest)