### PR TITLE
fix: use non-container object in test_untracked_containers for Python 3.14+ (Fixes #177)

### DIFF
--- a/test/muppy/test_muppy.py
+++ b/test/muppy/test_muppy.py
@@ -207,10 +207,16 @@ class MuppyTest(unittest.TestCase):
         gc.enable()
 
     def test_untracked_containers(self):
-        """Test whether untracked container objects are detected.
+        """Test whether untracked non-container objects referenced by
+        tracked containers are detected.
+
+        In Python 3.14+, empty dicts are tracked by the GC, so we can no
+        longer rely on ``{}`` being untracked.  Instead we use an integer
+        (never tracked) and make sure the parent dict contains another
+        container so that *it* is tracked.
         """
-        untracked = {}
-        tracked = {'untracked': untracked}
+        untracked = 42
+        tracked = {'untracked': untracked, 'marker': [1]}
         self.assertTrue(gc.is_tracked(tracked))
         self.assertFalse(gc.is_tracked(untracked))
         objects = [id(o) for o in muppy.get_objects()]


### PR DESCRIPTION
Fixes #177

## Problem

`MuppyTest.test_untracked_containers` fails on Python 3.14 because empty dicts are now tracked by the GC from creation time (CPython `d28b223`). The test creates `untracked = {}` and asserts `gc.is_tracked(untracked)` is `False`, which no longer holds.

## Solution

Replace the empty dict with an integer (`42`), which is a non-container object and is never tracked by the GC in any Python version. Add a list value to the parent dict to ensure it contains a container reference and is reliably tracked by the GC across all versions.

**Before:**
```python
untracked = {}
tracked = {'untracked': untracked}
```

**After:**
```python
untracked = 42
tracked = {'untracked': untracked, 'marker': [1]}
```

## Verification

All 31 muppy tests pass (the 1 failure in `test_repr_function` is pre-existing and unrelated — it's a path prefix issue from how the test runner is invoked):

```
test/muppy/test_muppy.py::MuppyTest::test_untracked_containers PASSED
31 passed, 1 failed (pre-existing) in 48.90s
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
